### PR TITLE
Add PoC ksonnet integration

### DIFF
--- a/jsonnet/honeycomb-agent-ds-app.jsonnet
+++ b/jsonnet/honeycomb-agent-ds-app.jsonnet
@@ -4,4 +4,5 @@ local custom = import "honeycomb-agent-ds-custom.libsonnet";
 // Import Honeycomb agent DaemonSet, append volume to it. The output
 // of this equivalent to `honeycomb-agent-ds-custom.json`.
 honeycomb.base("honeycomb-agent-v1.1", "kube-system") +
-custom.daemonSet.configVolumeMixin("config")
+custom.daemonSet.addHostMountedPodLogs("varlog", "varlibdockercontainers")
+  // + custom.daemonSet.configVolumeMixin("config")

--- a/jsonnet/honeycomb-agent-ds-base.libsonnet
+++ b/jsonnet/honeycomb-agent-ds-base.libsonnet
@@ -18,10 +18,6 @@ local honeycombLabels = {
   version: "v1.1",
 };
 
-local varlogVol = volume.fromHostPath("varlog", "/var/log");
-local varlibVol =
-  volume.fromHostPath("varlibdockercontainers", "/var/lib/docker/containers");
-
 local dsContainer =
   container.new("honeycomb-agent", "honeycombio/fluentd-honeycomb:1.23") +
   container.command([
@@ -31,10 +27,6 @@ local dsContainer =
   ]) +
   container.mixin.resources.limits({memory: "200Mi"}) +
   container.mixin.resources.requests({memory: "200Mi", cpu: "100m"}) +
-  container.volumeMounts([
-    volumeMount.new(varlogVol.name, varlogVol.hostPath.path),
-    volumeMount.new(varlibVol.name, varlibVol.hostPath.path, true)
-  ]) +
   container.env([
     envVar.fromSecretRef("HONEYCOMB_WRITEKEY", "honeycomb-writekey", "key"),
     envVar.new("HONEYCOMB_DATASET", "kubernetes"),
@@ -56,6 +48,5 @@ local dsContainer =
     // Template.
     ds.mixin.spec.template.metadata.labels(honeycombLabels) +
     ds.mixin.spec.template.spec.containers(dsContainer) +
-    ds.mixin.spec.template.spec.terminationGracePeriodSeconds(30) +
-    ds.mixin.spec.template.spec.volumes([varlogVol, varlibVol])
+    ds.mixin.spec.template.spec.terminationGracePeriodSeconds(30)
 }

--- a/jsonnet/honeycomb-agent-ds.json
+++ b/jsonnet/honeycomb-agent-ds.json
@@ -56,7 +56,8 @@
                   "volumeMounts": [
                      {
                         "mountPath": "/var/log",
-                        "name": "varlog"
+                        "name": "varlog",
+                        "readOnly": false
                      },
                      {
                         "mountPath": "/var/lib/docker/containers",


### PR DESCRIPTION
I've made the editorial decision to set this PR up as 3 commits to highlight the gradual workflow of transitioning a codebase to ksonnet. The commit messages are self-contained, and the comments explain what the code does, but for posterity, let me briefly describe them here:

1. Transforming the existing YAML Kubernetes API objects to JSON, so that we can import them and append the ksonnet mixins to them. (Jsonnet in general, and ksonnet in particular, does not currently support importing YAML documents.)
1. Introducing a ksonnet mixin that will configure add a Honeycomb agent `ConfigMap` to a `DaemonSet`, and then mount that `ConfigMap` on specified `Container`s.
1. Rewrite the Honeycomb agent in ksonnet, just to show what it's like.

To use this yourself, you will need 2 things:

1. [Jsonnet PR #318](https://github.com/google/jsonnet/pull/318). Building _should_ be painless on OS X and Linux, I haven't seen a build failure yet. This should be merged soon (see issue [#311](https://github.com/google/jsonnet/issues/311))
1. The [`hausdorff:honeycomb`](https://github.com/hausdorff/ksonnet-lib/tree/honeycomb) branch of `ksonnet-lib`. I have taken some liberties and written some extensions to the core mixin library to make this stuff a little more approachable.

Once you have both those things, compile using the `-J` flag, pointing at the directory `ksonnet-lib/ksonnet.beta.2`, and the rest should work ✨ magically ✨ 