### PR TITLE
Add tolerations and update strategy

### DIFF
--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -60,6 +60,9 @@ metadata:
   name: honeycomb-agent-v1.1
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: rollingUpdate
+    maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -67,6 +70,9 @@ spec:
         kubernetes.io/cluster-service: 'true'
         version: v1.1
     spec:
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
       containers:
       - env:
         - name: HONEYCOMB_WRITEKEY


### PR DESCRIPTION
* Added RollingUpdate strategy to the daemonset. This will enable a
better lifecycle for the pods deployed. ref:
https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/

* Added a toleration that will ensure that the agent is scheduled on all
nodes not just the workers. This example uses a pattern that will
include all nodes regardless of taint. ref:
http://blog.kubernetes.io/2017/03/advanced-scheduling-in-kubernetes.html