### PR TITLE
Add support for parsing Redis logs

### DIFF
--- a/parsers/glog.go
+++ b/parsers/glog.go
@@ -70,36 +70,6 @@ func (pf *GlogParserFactory) New() Parser {
 	}
 }
 
-// From https://github.com/honeycombio/honeytail/blob/master/parsers/extregexp.go,
-// but we don't need to vendor all of honeytail.
-// extRegexp is a Regexp with one additional method to make it easier to work
-// with named groups
-type extRegexp struct {
-	*regexp.Regexp
-}
-
-// FindStringSubmatchMap behaves the same as FindStringSubmatch except instead
-// of a list of matches with the names separate, it returns the full match and a
-// map of named submatches
-func (r *extRegexp) FindStringSubmatchMap(s string) (string, map[string]string) {
-	match := r.FindStringSubmatch(s)
-	if match == nil {
-		return "", nil
-	}
-
-	captures := make(map[string]string)
-	for i, name := range r.SubexpNames() {
-		if i == 0 {
-			continue
-		}
-		if name != "" {
-			// ignore unnamed matches
-			captures[name] = match[i]
-		}
-	}
-	return match[0], captures
-}
-
 func parseGlogTimestamp(month string, day string, hour string, minute string, second string, microsecond string) (time.Time, error) {
 	year := time.Now().Year()
 	var err error

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -26,6 +26,8 @@ func NewParserFactory(config *config.ParserConfig) (ParserFactory, error) {
 		factory = &NginxParserFactory{}
 	case "glog":
 		factory = &GlogParserFactory{}
+	case "redis":
+		factory = &RedisParserFactory{}
 	default:
 		return nil, fmt.Errorf("Unknown parser type %s", config.Name)
 	}

--- a/parsers/redis.go
+++ b/parsers/redis.go
@@ -1,0 +1,71 @@
+package parsers
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// The only reference I can find for this format is:
+// http://build47.com/redis-log-format-levels/
+// This formatter targets Redis 3+, which was released in January 2016
+const redisLineFormat = `(?P<pid>[0-9]+):(?P<role>[XCSM])\s(?P<timestamp>[0-9]{2}\s[A-Za-z]*\s[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)\s(?P<level>[.\-*#])\s(?P<message>.*)`
+const redisDateFormat = "02 Jan 15:04:05.000"
+
+var redisRoles = map[string]string{
+	"X": "sentinel",
+	"C": "child",
+	"S": "slave",
+	"M": "master",
+}
+
+var redisLevels = map[string]string{
+	".": "debug",
+	"-": "verbose",
+	"*": "notice",
+	"#": "warning",
+}
+
+type RedisParser struct {
+	re *extRegexp
+}
+
+func (p *RedisParser) Parse(line string) (map[string]interface{}, error) {
+	_, captures := p.re.FindStringSubmatchMap(line)
+
+	if captures == nil {
+		return nil, fmt.Errorf("Couldn't parse line as Redis line: %s", line)
+	}
+
+	ret := make(map[string]interface{}, 0)
+	if level, ok := redisLevels[captures["level"]]; ok {
+		ret["level"] = level
+	} else {
+		ret["level"] = captures["level"]
+	}
+	if role, ok := redisRoles[captures["role"]]; ok {
+		ret["role"] = role
+	} else {
+		ret["role"] = captures["role"]
+	}
+	ret["pid"] = captures["pid"]
+	ret["message"] = captures["message"]
+
+	ts, err := time.Parse(redisDateFormat, captures["timestamp"])
+	if err == nil {
+		ts = ts.AddDate(time.Now().Year(), 0, 0)
+		ret["redis_timestamp"] = ts
+	}
+
+	return ret, nil
+}
+
+type RedisParserFactory struct{}
+
+func (pf *RedisParserFactory) Init(options map[string]interface{}) error { return nil }
+
+func (pf *RedisParserFactory) New() Parser {
+	return &RedisParser{
+		re: &extRegexp{regexp.MustCompile(redisLineFormat)},
+	}
+}

--- a/parsers/regexp_extension.go
+++ b/parsers/regexp_extension.go
@@ -1,0 +1,33 @@
+package parsers
+
+import "regexp"
+
+// From https://github.com/honeycombio/honeytail/blob/master/parsers/extregexp.go,
+// but we don't need to vendor all of honeytail.
+// extRegexp is a Regexp with one additional method to make it easier to work
+// with named groups
+type extRegexp struct {
+	*regexp.Regexp
+}
+
+// FindStringSubmatchMap behaves the same as FindStringSubmatch except instead
+// of a list of matches with the names separate, it returns the full match and a
+// map of named submatches
+func (r *extRegexp) FindStringSubmatchMap(s string) (string, map[string]string) {
+	match := r.FindStringSubmatch(s)
+	if match == nil {
+		return "", nil
+	}
+
+	captures := make(map[string]string)
+	for i, name := range r.SubexpNames() {
+		if i == 0 {
+			continue
+		}
+		if name != "" {
+			// ignore unnamed matches
+			captures[name] = match[i]
+		}
+	}
+	return match[0], captures
+}


### PR DESCRIPTION
This is based directly on the glog parser and pulls out the regexp
extension into a separate file depended on by both.