### PR TITLE
Fix log handling for critical pods

### DIFF
--- a/k8sagent/watcher.go
+++ b/k8sagent/watcher.go
@@ -63,6 +63,12 @@ func (w *PodWatcherImpl) onAdd(obj interface{}) {
 		return
 	}
 
+	logrus.WithFields(logrus.Fields{
+		"UID":    pod.UID,
+		"Name":   pod.Name,
+		"Action": "Add",
+	}).Debug("Watcher got new pod")
+
 	w.Lock()
 	defer w.Unlock()
 	_, ok = w.watchMap[pod.UID]
@@ -79,6 +85,13 @@ func (w *PodWatcherImpl) onUpdate(oldObj interface{}, newObj interface{}) {
 		logrus.Error("Watcher got new object of unexpected type")
 		return
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"UID":    pod.UID,
+		"Name":   pod.Name,
+		"Action": "Update",
+	}).Debug("Watcher got updated pod")
+
 	w.Lock()
 	defer w.Unlock()
 	_, ok = w.watchMap[pod.UID]
@@ -96,6 +109,13 @@ func (w *PodWatcherImpl) onDelete(obj interface{}) {
 		logrus.Error("Watcher got new object of unexpected type")
 		return
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"UID":    pod.UID,
+		"Name":   pod.Name,
+		"Action": "Delete",
+	}).Debug("Watcher got pod")
+
 	w.Lock()
 	defer w.Unlock()
 	delete(w.watchMap, pod.UID)

--- a/tailer/tailer.go
+++ b/tailer/tailer.go
@@ -37,6 +37,10 @@ func (t *Tailer) Run() error {
 	if t.stateRecorder != nil {
 		if offset, err := t.stateRecorder.Get(t.path); err == nil {
 			seekInfo.Offset = offset
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"Path": t.path,
+			}).WithError(err).Error("error getting state")
 		}
 	}
 	tailConf := tail.Config{
@@ -163,6 +167,11 @@ func (p *PathWatcher) check() {
 	files, err := filepath.Glob(p.pattern)
 	if err != nil {
 		logrus.WithError(err).Error("Error globbing files")
+	}
+	if len(files) == 0 {
+		logrus.WithFields(logrus.Fields{
+			"Pattern": p.pattern,
+		}).Warn("No files found for pattern")
 	}
 	current := make(map[string]struct{}, len(p.tailers))
 	for _, file := range files {


### PR DESCRIPTION
The logs for these pods use a different convention for their log paths. (I can't find any documentation for this, might have to dig into the k8s source). In order to read logs for things like kube-apiserver we need to adjust the path based on the presence of a particular annotation in the pod metadata.