### PR TITLE
Fix nil pointer dereference when state file open fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	stateRecorder, err := tailer.NewStateRecorder("/var/log/honeycomb-agent.state")
 	if err != nil {
-		logrus.WithError(err).Error("Error initializing state recorder")
+		logrus.WithError(err).Error("Error initializing state recorder. Agent progress won't be persisted across restarts.")
 	}
 
 	for _, watcherConfig := range config.Watchers {

--- a/tailer/state.go
+++ b/tailer/state.go
@@ -20,7 +20,7 @@ type StateRecorderImpl struct {
 	db *bolt.DB
 }
 
-func NewStateRecorder(stateFilePath string) (*StateRecorderImpl, error) {
+func NewStateRecorder(stateFilePath string) (StateRecorder, error) {
 	db, err := bolt.Open(stateFilePath, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return nil, err

--- a/tailer/tailer_test.go
+++ b/tailer/tailer_test.go
@@ -153,3 +153,18 @@ func TestPathWatching(t *testing.T) {
 	}
 	assert.Equal(t, len(watcher.tailers), 0)
 }
+
+func TestTailingWithoutStateRecorder(t *testing.T) {
+	// Make sure that the tailer doesn't panic even when given a nil state recorder
+	stateRecorder, err := NewStateRecorder("/nope/wtf")
+	assert.Error(t, err)
+
+	handler := &mockLineHandler{}
+
+	logFile, err := ioutil.TempFile("/tmp", "honeycomb-log-test")
+	logFile.Write([]byte("line1\n"))
+	logFile.Sync()
+	tailer := NewTailer(logFile.Name(), handler, stateRecorder)
+	tailer.Run()
+	tailer.Stop()
+}


### PR DESCRIPTION
This mystery turns out to be yet another episode of the unoriginal
crime series in which the serial culprit is always the same
(https://golang.org/doc/faq#nil_error), as is the unwitting victim (me).

If `StateRecorder` initialization fails, we log an error but continue
execution. All access to the `StateRecorder` is *supposed* to be guarded
by nil checks. However, an interface wrapping a nil pointer of a
concrete type does not compare equal to nil. 

Fix this by ensuring that we return the nil *interface* from `NewStateRecorder`, 
while surpressing the urge to hurl all computers into the cold, bottomless
ocean.

Test plan: new unit tests