### PR TITLE
Add parser shortcut for nginx ingress logs

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -184,6 +184,40 @@ func TestNginxParsing(t *testing.T) {
 		{
 			config: `{
 				"dataset": "kubernetestest",
+				"parser": { "name": "nginx-ingress" },
+				"processors":
+			}`,
+			unwrapperType: docker_json,
+			lines: []string{
+				`{"log":"10.0.0.1 - [10.0.0.1] - - [14/Jun/2018:18:20:48 +0000] \"GET /api/v1/users?id=22 HTTP/1.1\" 200 1198 \"-\" \"curl\" 536 0.165 [api-22] 10.0.0.2:10001 1202 0.165 200 abcd\n","stream":"stdout","time":"2017-07-10T22:10:25Z"}`,
+			},
+			output: []event.Event{
+				{
+					Data: map[string]interface{}{
+						"the_real_ip":              "10.0.0.1",
+						"time_local":               "14/Jun/2018:18:20:48 +0000",
+						"request":                  "GET /api/v1/users?id=22 HTTP/1.1",
+						"status":                   int64(200),
+						"body_bytes_sent":          int64(1198),
+						"http_user_agent":          "curl",
+						"request_length":           int64(536),
+						"request_time":             0.165,
+						"proxy_upstream_name":      "api-22",
+						"upstream_addr":            "10.0.0.2:10001",
+						"upstream_response_length": int64(1202),
+						"upstream_response_time":   0.165,
+						"upstream_status":          int64(200),
+						"req_id":                   "abcd",
+					},
+					Dataset:   "kubernetestest",
+					Path:      "/tmp/testpath",
+					Timestamp: time.Date(2017, 7, 10, 22, 10, 25, 0, time.UTC),
+				},
+			},
+		},
+		{
+			config: `{
+				"dataset": "kubernetestest",
 				"parser": {
 					"name": "nginx",
 					"options": { "log_format": "[$time_local] \"$request\" $status" }

--- a/parsers/nginx.go
+++ b/parsers/nginx.go
@@ -16,6 +16,10 @@ const defaultLogFormat = `$remote_addr - $remote_user [$time_local] "$request" $
 // https://envoyproxy.github.io/envoy/configuration/http_conn_man/access_log.html#config-http-con-manager-access-log-default-format
 const envoyLogFormat = `[$timestamp] "$request" $status_code $response_flags $bytes_received $bytes_sent $duration $x_envoy_upstream_service_time "$x_forwarded_for" "$user_agent" "$x_request_id" "$authority" "$upstream_host"`
 
+// nginx ingress default log format
+// https://github.com/kubernetes/ingress-nginx/blob/9c6201b79a8b4/internal/ingress/controller/config/config.go#L53
+const nginxIngressLogFormat = `$the_real_ip - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id`
+
 type NginxParserFactory struct {
 	parserName string
 	logFormat  string
@@ -25,6 +29,9 @@ func (pf *NginxParserFactory) Init(options map[string]interface{}) error {
 	logFormat := defaultLogFormat
 	if pf.parserName == "envoy" {
 		logFormat = envoyLogFormat
+	}
+	if pf.parserName == "nginx-ingress" {
+		logFormat = nginxIngressLogFormat
 	}
 	if logFormatOption, ok := options["log_format"]; ok {
 		typedLogFormatOption, ok := logFormatOption.(string)
@@ -37,6 +44,8 @@ func (pf *NginxParserFactory) Init(options map[string]interface{}) error {
 			logFormat = defaultLogFormat
 		case "envoy":
 			logFormat = envoyLogFormat
+		case "nginx-ingress":
+			logFormat = nginxIngressLogFormat
 		default:
 			logFormat = typedLogFormatOption
 		}

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -22,7 +22,7 @@ func NewParserFactory(config *config.ParserConfig) (ParserFactory, error) {
 		factory = &JSONParserFactory{}
 	case "nop":
 		factory = &NoOpParserFactory{}
-	case "nginx", "envoy":
+	case "nginx", "envoy", "nginx-ingress":
 		factory = &NginxParserFactory{
 			// Default log format depends on the parser name specified in
 			// configuration


### PR DESCRIPTION
In Kubernetes, an _Ingress_ resource manages external access to
resources in a cluster. The details are kind of laden with Kubernetes
jargon, but the key point is that it's common to run NGINX as a sort of
cluster-wide proxy to the services that you run inside the cluster.

When run this way, nginx is configured to use a non-default logging
format. As a result, several users have reported trouble configuring
`honeycomb-kubernetes-agent` to parse nginx ingress logs. You can
technically do it by providing a custom log format in the agent's
configuration, but it's really verbose and opaque.

Make this easier by providing a shortcut: if you want to parse nginx
ingress logs, you can simply specify `parser: nginx-ingress` when
configuring the agent. I'll follow up with a docs patch as well.

Fixes #14.

Test plan: new unit tests.