### PR TITLE
Stop PodWatchers after pods are deleted

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -537,6 +537,8 @@ type mockPodGetter struct{}
 
 func (mp *mockPodGetter) Pods() chan *v1.Pod { return nil }
 
+func (mp *mockPodGetter) DeletedPods() chan types.UID { return nil }
+
 func (mp *mockPodGetter) Get(uid types.UID) (*v1.Pod, bool) {
 	return &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
We're good about starting watchers when pods are created, but never clean up. This ends up with lots of log spam as we try and glob the log directory for non-existent pod dirs once per sec for every missing pod.