### PR TITLE
Allow override of pod log base path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Config struct {
-	APIHost   string `yaml:"apiHost"`
-	WriteKey  string `yaml:"writekey"`
-	Watchers  []*WatcherConfig
-	Verbosity string
+	APIHost        string `yaml:"apiHost"`
+	WriteKey       string `yaml:"writekey"`
+	Watchers       []*WatcherConfig
+	Verbosity      string
+	LegacyLogPaths bool `yaml:"legacyLogPaths"`
 }
 
 type WatcherConfig struct {

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -47,6 +47,9 @@ data:
         labelSelector: ""
         parser: glog
     verbosity: debug
+    # support older container log paths, see:
+    # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md
+    legacyLogPaths: true
 
 # Daemonset
 ---

--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func main() {
 				transmitter,
 				stateRecorder,
 				kubeClient,
+				config.LegacyLogPaths,
 			)
 			pt.Start()
 			defer pt.Stop()

--- a/podtailer/podtailer_test.go
+++ b/podtailer/podtailer_test.go
@@ -1,0 +1,68 @@
+package podtailer
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func TestDetermineFilterFuncLegacyLogs(t *testing.T) {
+	pod := &v1.Pod{}
+	pod.Name = "foo"
+	pod.Namespace = "default"
+	expected := func(fileName string) bool {
+		re := fmt.Sprintf(
+			"^/var/log/containers/%s_%s_%s-.+\\.log",
+			"foo",
+			"default",
+			"wibble",
+		)
+		ok, _ := regexp.Match(re, []byte(fileName))
+		return ok
+	}
+
+	f := determineFilterFunc(pod, "wibble", true)
+	// functions should have same output
+	assert.Equal(
+		t,
+		expected("/var/log/containers/foo_default_wibble-abcdefg.log"),
+		f("/var/log/containers/foo_default_wibble-abcdefg.log"),
+	)
+
+	assert.Equal(
+		t,
+		expected("/var/log/containers/foo_default_wobble-abcdefg.log"),
+		f("/var/log/containers/foo_default_wobble-abcdefg.log"),
+	)
+}
+
+func TestDetermineFilterFunc(t *testing.T) {
+	pod := &v1.Pod{}
+	pod.UID = "123456"
+
+	expected := func(fileName string) bool {
+		re := fmt.Sprintf(
+			"^/var/log/pods/%s/%s_[0-9]*\\.log",
+			"123456",
+			"wibble",
+		)
+		ok, _ := regexp.Match(re, []byte(fileName))
+		return ok
+	}
+
+	f := determineFilterFunc(pod, "wibble", false)
+	assert.Equal(
+		t,
+		expected("/var/log/pods/123456/wibble_0.log"),
+		f("/var/log/pods/123456/wibble_0.log"),
+	)
+
+	assert.Equal(
+		t,
+		expected("/var/log/pods/123456/wobble_0.log"),
+		f("/var/log/pods/123456/wobble_0.log"),
+	)
+}


### PR DESCRIPTION
Customer has a k8s cluster where the logs are still writen to /var/log/containers, under the old spec. See here: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md - this allows support of both paths using an optional argument to the agent config file.