### PR TITLE
Clarify spurious "error getting state" log

### DIFF
--- a/tailer/tailer.go
+++ b/tailer/tailer.go
@@ -39,8 +39,9 @@ func (t *Tailer) Run() error {
 			seekInfo.Offset = offset
 		} else {
 			logrus.WithFields(logrus.Fields{
-				"Path": t.path,
-			}).WithError(err).Error("error getting state")
+				"path":   t.path,
+				"detail": err,
+			}).Info("no prior tail state found")
 		}
 	}
 	tailConf := tail.Config{


### PR DESCRIPTION
Currently we emit this error every time we start tailing a file, which
is confusing to users, especially if they have some other problem
ingesting logs. Change it to a more innocuous message.