### PR TITLE
[podtailer] support yet another log pattern

### DIFF
--- a/podtailer/podtailer_test.go
+++ b/podtailer/podtailer_test.go
@@ -2,6 +2,9 @@ package podtailer
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -9,7 +12,75 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+func TestDetermineLogPatternK8S110(t *testing.T) {
+	t.Parallel()
+	pod := &v1.Pod{}
+	pod.Name = "foo"
+	pod.UID = "123456"
+
+	path, err := ioutil.TempDir("", "")
+	assert.Nil(t, err)
+	defer os.RemoveAll(path)
+
+	err = os.Mkdir(filepath.Join(path, "pods"), 0777)
+	assert.Nil(t, err)
+	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID)), 0777)
+	assert.Nil(t, err)
+	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID), "container1"), 0777)
+	assert.Nil(t, err)
+	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID), "container2"), 0777)
+	assert.Nil(t, err)
+	_, err = os.Create(filepath.Join(path, "pods", string(pod.UID), "container1", "0.log"))
+	assert.Nil(t, err)
+	_, err = os.Create(filepath.Join(path, "pods", string(pod.UID), "container2", "0.log"))
+	assert.Nil(t, err)
+
+	p, err := determineLogPattern(pod, path, false)
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(path, "pods", string(pod.UID), "*", "*"), p)
+}
+
+func TestDetermineLogPatternPreK8S110(t *testing.T) {
+	t.Parallel()
+	pod := &v1.Pod{}
+	pod.Name = "foo"
+	pod.UID = "123456"
+
+	path, err := ioutil.TempDir("", "")
+	assert.Nil(t, err)
+	defer os.RemoveAll(path)
+
+	err = os.Mkdir(filepath.Join(path, "pods"), 0777)
+	assert.Nil(t, err)
+	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID)), 0777)
+	assert.Nil(t, err)
+	_, err = os.Create(filepath.Join(path, "pods", string(pod.UID), "container1_0.log"))
+	assert.Nil(t, err)
+	_, err = os.Create(filepath.Join(path, "pods", string(pod.UID), "container2_0.log"))
+	assert.Nil(t, err)
+
+	p, err := determineLogPattern(pod, path, false)
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(path, "pods", string(pod.UID), "*"), p)
+}
+
+func TestDetermineLogPatternLegacy(t *testing.T) {
+	t.Parallel()
+	pod := &v1.Pod{}
+	pod.Name = "foo"
+	pod.UID = "123456"
+	pod.Namespace = "xyz"
+
+	path, err := ioutil.TempDir("", "")
+	assert.Nil(t, err)
+	defer os.RemoveAll(path)
+	p, err := determineLogPattern(pod, path, true)
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(path, "containers", fmt.Sprintf("%s_%s_*.log", pod.Name, pod.Namespace)), p)
+}
+
 func TestDetermineFilterFuncLegacyLogs(t *testing.T) {
+	t.Parallel()
 	pod := &v1.Pod{}
 	pod.Name = "foo"
 	pod.Namespace = "default"
@@ -40,6 +111,7 @@ func TestDetermineFilterFuncLegacyLogs(t *testing.T) {
 }
 
 func TestDetermineFilterFunc(t *testing.T) {
+	t.Parallel()
 	pod := &v1.Pod{}
 	pod.UID = "123456"
 
@@ -64,5 +136,37 @@ func TestDetermineFilterFunc(t *testing.T) {
 		t,
 		expected("/var/log/pods/123456/wobble_0.log"),
 		f("/var/log/pods/123456/wobble_0.log"),
+	)
+}
+
+func TestDetermineFilterFuncK8S1Dot10(t *testing.T) {
+	t.Parallel()
+	// Format changed in 1.10 to
+	// /var/log/pods/<uid>/<containerName>/N.log
+	// Handle it if we see it
+	pod := &v1.Pod{}
+	pod.UID = "123456"
+
+	expected := func(fileName string) bool {
+		re := fmt.Sprintf(
+			"^/var/log/pods/%s/%s/[0-9]*\\.log",
+			"123456",
+			"wibble",
+		)
+		ok, _ := regexp.Match(re, []byte(fileName))
+		return ok
+	}
+
+	f := determineFilterFunc(pod, "wibble", false)
+	assert.Equal(
+		t,
+		expected("/var/log/pods/123456/wibble/0.log"),
+		f("/var/log/pods/123456/wibble/0.log"),
+	)
+
+	assert.Equal(
+		t,
+		expected("/var/log/pods/123456/wobble/0.log"),
+		f("/var/log/pods/123456/wobble/0.log"),
 	)
 }


### PR DESCRIPTION
Looks like the log pattern changed again in 1.10. I am unable to find any documentation about this change in the changelog or elsewhere, but confirmed with minikube that the log directory pattern is indeed this:

`/var/log/pods/<podUID>/<containerName>/<instance>.log`

This is a change from pre-1.10 which was:

`/var/log/pods/<podUID>/<containerName>_instance.log`

In this diff we detect both and act accordingly. Not too thrilled about the approach in `determineFilterFunc` but this should get us working again in 1.10 clusters. With more cycles we can re-imagine the logging process to be version-aware or something.