### PR TITLE
[logrus] add output hook to optionally direct trace, info, debug, and…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Watchers       []*WatcherConfig
 	Verbosity      string
 	LegacyLogPaths bool `yaml:"legacyLogPaths"`
+	SplitLogging   bool `yaml:"splitLogging"`
 }
 
 type WatcherConfig struct {


### PR DESCRIPTION
… warn to stdout

Addresses https://github.com/honeycombio/honeycomb-kubernetes-agent/issues/26 by providing a new config option, `splitLogging`, to enable certain log severities to go to stdout rather than stderr. I chose to make this optional as I do not want to introduce new behavior into the agent for all users, which may rely on everything going to stderr.