### PR TITLE
Handle race between appearance of pod and log files on disk

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,9 +123,130 @@ daemonset "honeycomb-agent-v1.1" deleted
 
 Once you've done that, rebuild your container image and reapply the spec! 
 
+### Smoketesting multiple K8S versions with Minikube
 
+Testing the agent against each version of Kubernetes is tedious, but hopefully this can streamline the process for you.
 
+**Requirements**
 
+- minikube
+- virtualbox (assumes you have a VM driver)
 
+#### Steps
 
+**1. Launch the version of the k8s cluster you want**
 
+```bash
+$ cd smoketest
+$ ./test-k8s.sh 1.10.1
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 51.3M  100 51.3M    0     0  3319k      0  0:00:15  0:00:15 --:--:-- 7245k
+/Users/tredman/go/src/github.com/honeycombio/honeycomb-kubernetes-agent/smoketest
+Deleting local Kubernetes cluster...
+Machine deleted.
+Starting local Kubernetes v1.10.1 cluster...
+Starting VM...
+Getting VM IP address...
+Moving files into cluster...
+Downloading kubeadm v1.10.1
+Downloading kubelet v1.10.1
+Finished Downloading kubelet v1.10.1
+Finished Downloading kubeadm v1.10.1
+Setting up certs...
+Connecting to cluster...
+Setting up kubeconfig...
+Starting cluster components...
+Kubectl is now configured to use the cluster.
+Loading cached images from config file.
+```
+
+This will use minikube to launch the specified version in your virtualbox environment, and download the right kubectl for that version.
+
+**2. Put the kubectl in your path temporarily**
+
+```bash
+$ source ./activate.sh
+```
+
+**3. Verify the k8s/kubectl versions are correct**
+
+```bash
+$ kubectl version
+Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:26:04Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"darwin/amd64"}
+Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:14:26Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+```
+
+**4. Install the k8s agent**
+
+```bash
+$ kubectl apply -f quickstart.yaml
+serviceaccount "honeycomb-serviceaccount" created
+clusterrolebinding.rbac.authorization.k8s.io "honeycomb-serviceaccount" created
+clusterrole.rbac.authorization.k8s.io "honeycomb-serviceaccount" created
+configmap "honeycomb-agent-config" created
+daemonset.extensions "honeycomb-agent-v1.1" created
+secret "honeycomb-writekey" created
+```
+
+**5. Optionally install the "guestbook-frontend" sample app**
+
+This will give you a pod that the Honeycomb agent should pick up.
+
+```bash
+$ kubectl apply -f frontend-deployment.yaml
+deployment.apps "frontend" created
+$ kubectl get pods
+NAME                         READY     STATUS              RESTARTS   AGE
+frontend-5c548f4769-p6j8k    0/1       ContainerCreating   0          48s
+honeycomb-agent-v1.1-8vdb9   0/1       ContainerCreating   0          3s
+```
+
+**6. Push your version of the agent to k8s**
+
+```bash
+# from the repo root
+$ make container
+building: bin/amd64/honeycomb-kubernetes-agent
+Sending build context to Docker daemon  196.4MB
+Step 1/5 : FROM golang:1.8-alpine
+ ---> 4cb86d3661bf
+Step 2/5 : MAINTAINER Team Honeycomb <bees@honeycomb.io>
+ ---> Using cache
+ ---> c2d6551e3573
+Step 3/5 : ADD bin/amd64/honeycomb-kubernetes-agent /honeycomb-kubernetes-agent
+ ---> 6ff387285b08
+Step 4/5 : USER root:root
+ ---> Running in b8e0ef6f3468
+Removing intermediate container b8e0ef6f3468
+ ---> 1d0609ade8fd
+Step 5/5 : ENTRYPOINT ["/honeycomb-kubernetes-agent"]
+ ---> Running in 8606e25648b0
+Removing intermediate container 8606e25648b0
+ ---> b6d13547c350
+Successfully built b6d13547c350
+Successfully tagged honeycombio/honeycomb-kubernetes-agent:5828ce8-dirty
+container: honeycombio/honeycomb-kubernetes-agent:5828ce8-dirty
+
+# now deploy it to your cluster
+$ docker save honeycombio/honeycomb-kubernetes-agent:5828ce8-dirty | pv | (eval $(minikube docker-env) && docker load)
+```
+
+Update the quickstart.yaml with this development tag and redeploy:
+
+```yaml
+image: honeycombio/honeycomb-kubernetes-agent:CHANGEMETODEVTAG
+```
+
+```bash
+$ kubectl apply -f quickstart.yaml
+```
+
+**7. Check the logs, poke around, verify your code, etc**
+
+```bash
+$ kubectl logs -l k8s-app=honeycomb-agent
+time="2018-11-09T22:01:48Z" level=debug msg="Starting informer" fieldSelector="spec.nodeName=minikube" labelSelector="k8s-app=kube-controller-manager,k8s-app!=honeycomb-agent" namespace=kube-system
+time="2018-11-09T22:01:48Z" level=debug msg="Starting informer" fieldSelector="spec.nodeName=minikube" labelSelector="app=guestbook,k8s-app!=honeycomb-agent" namespace=default
+...
+```

--- a/smoketest/activate.sh
+++ b/smoketest/activate.sh
@@ -1,0 +1,3 @@
+kubectl_path=$(pwd)/bin
+
+export PATH="${kubectl_path}:${PATH}"

--- a/smoketest/bin/.gitignore
+++ b/smoketest/bin/.gitignore
@@ -1,0 +1,1 @@
+kubectl*

--- a/smoketest/frontend-deployment.yaml
+++ b/smoketest/frontend-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # Using `GET_HOSTS_FROM=dns` requires your cluster to
+          # provide a dns service. As of Kubernetes 1.3, DNS is a built-in
+          # service launched automatically. However, if the cluster you are using
+          # does not have a built-in DNS service, you can instead
+          # instead access an environment variable to find the master
+          # service's host. To do so, comment out the 'value: dns' line above, and
+          # uncomment the line below:
+          # value: env
+        ports:
+        - containerPort: 80

--- a/smoketest/frontend-service.yaml
+++ b/smoketest/frontend-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 10.0.0.0/12
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # comment or delete the following line if you want to use a LoadBalancer
+  type: NodePort 
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  # type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend

--- a/smoketest/get-kubectl.sh
+++ b/smoketest/get-kubectl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+VERSION=$1
+
+if [ -z "${VERSION}" ]; then
+	echo "usage: $(basename $0) <version>"
+	echo "version = 1.x.x"
+	exit 1;
+fi;
+
+if [ "$(uname)" == "Darwin" ]; then
+	curl -L https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/darwin/amd64/kubectl -o bin/kubectl-${VERSION}
+else
+	curl -L https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/amd64/kubectl -o bin/kubectl-${VERSION}
+
+fi;

--- a/smoketest/quickstart.yaml
+++ b/smoketest/quickstart.yaml
@@ -1,0 +1,156 @@
+# Service account for the agent
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: honeycomb-serviceaccount
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: honeycomb-serviceaccount
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: honeycomb-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: honeycomb-serviceaccount
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: honeycomb-serviceaccount
+  namespace: default
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - list
+    - watch
+
+# ConfigMap specifying which logs the agent should watch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: honeycomb-agent-config
+  namespace: default
+data:
+  config.yaml: |-
+    # By default, submit logs from interesting system pods such as the
+    # kube API server
+    watchers:
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-apiserver"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-scheduler"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-controller-manager"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-proxy"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=dns-controller"
+        namespace: kube-system
+        parser: glog
+      - dataset: frontend
+        labelSelector: "app=guestbook"
+        namespace: default
+        parser: nop
+    verbosity: debug
+    # splitLogging directs trace, debug, info, and warn log levels to stdout
+    # rather than stderr.
+    splitLogging: false
+
+# Daemonset
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: honeycomb-agent
+    kubernetes.io/cluster-service: 'true'
+    version: v1.1
+  name: honeycomb-agent-v1.1
+  namespace: default
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: honeycomb-agent
+        kubernetes.io/cluster-service: 'true'
+        version: v1.1
+    spec:
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      containers:
+      - env:
+        - name: HONEYCOMB_WRITEKEY
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: honeycomb-writekey
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: honeycombio/honeycomb-kubernetes-agent:head
+        imagePullPolicy: IfNotPresent
+        name: honeycomb-agent
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: "/etc/honeycomb"
+          name: config
+          readOnly: false
+        - mountPath: "/var/log"
+          name: varlog
+          readOnly: false
+        - mountPath: "/var/lib/docker/containers"
+          name: varlibdockercontainers
+          readOnly: true
+      serviceAccountName: honeycomb-serviceaccount
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: honeycomb-agent-config
+        name: config
+      - hostPath:
+          path: "/var/log"
+        name: varlog
+      - hostPath:
+          path: "/var/lib/docker/containers"
+        name: varlibdockercontainers
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: honeycomb-writekey
+type: Opaque
+data:
+  key: Zm9vCg==
+

--- a/smoketest/test-k8s.sh
+++ b/smoketest/test-k8s.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+VERSION=$1
+
+if [ -z "${VERSION}" ]; then
+	echo "usage: $(basename $0) <version>"
+	echo "version = 1.x.x"
+	exit 1;
+fi;
+
+./get-kubectl.sh ${VERSION}
+
+rm -f bin/kubectl
+
+chmod +x bin/kubectl-${VERSION}
+
+cd bin
+
+ln -s kubectl-${VERSION} kubectl
+
+cd - 
+
+
+minikube delete
+
+minikube start --kubernetes-version v${VERSION}
+
+# remove taint on master so that we can schedule pods on it
+bin/kubectl taint nodes minikube node-role.kubernetes.io/master:NoSchedule-
+


### PR DESCRIPTION
Fixes https://github.com/honeycombio/honeycomb-kubernetes-agent/issues/25

When the K8s client signals a new pod to our watcher loop, the log files on disk are not necessarily in place yet. This can cause `determineLogPattern` to fail and return an empty pattern. As best as I can tell, we used to get away with this by falling back to a default pattern, but that's not always the best thing to do now that `determineLogPattern` is more complicated and has to address path differences between different versions of k8s. Instead, this adds a retry loop with backoff logic to the watcher loop. If `watcherForPod` fails, we'll retry a few times. In testing, this worked repeatably, but there may be some edge cases out there where the log files do not appear after many seconds. If that happens, we'll at least have a log line to identify those cases and we can come up with a better strategy.

Repro for this was:
- deploy some pod
- deploy k8s agent and see pod logs picked up
- redeploy pod and see "No files found for pattern" error

Also checking in a sort of smoke test environment that we can use in the future to quickly spin up different versions of k8s and deploy the agent on for testing. With it you can run a script to have minikube spin up the right environment, then deploy the agent and a test pod with only a couple of commands.