### PR TITLE
Add optional error dataset for parsing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ minikube-ds.yaml
 /.push-*
 /.container-*
 /.dockerfile-*
+.DS_Store

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,9 @@ type Config struct {
 	WriteKey       string `yaml:"writekey"`
 	Watchers       []*WatcherConfig
 	Verbosity      string
-	LegacyLogPaths bool `yaml:"legacyLogPaths"`
-	SplitLogging   bool `yaml:"splitLogging"`
+	LegacyLogPaths bool   `yaml:"legacyLogPaths"`
+	SplitLogging   bool   `yaml:"splitLogging"`
+	ErrorDataset   string `yaml:"errorDataset"`
 }
 
 type WatcherConfig struct {
@@ -27,6 +28,7 @@ type WatcherConfig struct {
 	FilePaths     []string `yaml:"paths"`
 	ContainerName string   `yaml:"containerName"`
 	Processors    []map[string]map[string]interface{}
+	ErrorDataset  string `yaml:"errorDataset"`
 }
 
 type ParserConfig struct {

--- a/main.go
+++ b/main.go
@@ -128,6 +128,11 @@ func main() {
 	}
 
 	for _, watcherConfig := range config.Watchers {
+		// propagate the error dataset if set globally, but not explicitly set
+		// for an individual watcher
+		if config.ErrorDataset != "" && watcherConfig.ErrorDataset == "" {
+			watcherConfig.ErrorDataset = config.ErrorDataset
+		}
 		for _, path := range watcherConfig.FilePaths {
 			handlerFactory, err := handlers.NewLineHandlerFactoryFromConfig(
 				watcherConfig,


### PR DESCRIPTION
This is similar to our implementation in the Agentless Integrations. Rather than log parsing errors locally (requiring debug mode and knowledge of kubectl-foo), allow an optional `ErrorDataset` in the config - either globally, or on a per-watcher basis. Parsing errors will get logged to this dataset. It's also possible to log errors to the same dataset as the watcher, but it's probably not a good idea so you have to be explicit about it.