### PR TITLE
[podtailer] determineLogPattern should fail if no files present

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,10 @@ func main() {
 				// before actually setting up the watcher
 				logrus.WithError(err).Error("Error setting up watcher")
 			}
-			t := tailer.NewPathWatcher(path, nil, handlerFactory, stateRecorder)
+			// Even though we have a static path, NewPathWatcher expects a function
+			// so we build one that just returns the path
+			patternFunc := func() (string, error) { return path, nil }
+			t := tailer.NewPathWatcher(patternFunc, nil, handlerFactory, stateRecorder)
 			t.Start()
 			defer t.Stop()
 		}

--- a/podtailer/podtailer.go
+++ b/podtailer/podtailer.go
@@ -207,7 +207,7 @@ func determineLogPattern(pod *v1.Pod, basePath string, legacyLogPaths bool) (str
 				"PodName": pod.Name,
 				"UID":     pod.UID,
 				"Path":    upath,
-			}).Info("insufficient information in pod log directory")
+			}).Info("no files in log path yet, could not determine log pattern")
 			return "", fmt.Errorf("Could not determine log path for pod %s", pod.UID)
 		}
 		for _, f := range files {
@@ -263,13 +263,10 @@ func determineFilterFunc(pod *v1.Pod, containerName string, legacyLogPaths bool)
 }
 
 func (pt *PodSetTailer) watcherForPod(pod *v1.Pod, containerName string, podWatcher k8sagent.PodWatcher) (*tailer.PathWatcher, error) {
-	pattern, err := determineLogPattern(pod, logsBasePath, pt.legacyLogPaths)
-	if err != nil {
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"Pod": pod.UID,
-		}).Warn("Error finding log path")
-
-		return nil, err
+	// at the time we try and start the watcher, the log directory contents may be insufficient
+	// to determine the right log pattern. Rather than fail, we just defer this until the watcher is running
+	patternFunc := func() (string, error) {
+		return determineLogPattern(pod, logsBasePath, pt.legacyLogPaths)
 	}
 
 	// only watch logs for containers matching the given name, if
@@ -292,11 +289,10 @@ func (pt *PodSetTailer) watcherForPod(pod *v1.Pod, containerName string, podWatc
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"Name":    pod.Name,
-		"UID":     pod.UID,
-		"Pattern": pattern,
+		"Name": pod.Name,
+		"UID":  pod.UID,
 	}).Info("Setting up watcher for pod")
 
-	watcher := tailer.NewPathWatcher(pattern, filterFunc, handlerFactory, pt.stateRecorder)
+	watcher := tailer.NewPathWatcher(patternFunc, filterFunc, handlerFactory, pt.stateRecorder)
 	return watcher, nil
 }

--- a/podtailer/podtailer.go
+++ b/podtailer/podtailer.go
@@ -200,6 +200,16 @@ func determineLogPattern(pod *v1.Pod, basePath string, legacyLogPaths bool) (str
 			}).WithError(err).Warn("failed to read pod log directory")
 			return "", fmt.Errorf("Could not determine log path for pod %s", pod.UID)
 		}
+		// it's possible that the pod log directory exists, but no files or directories
+		// exist so we can't know what the pattern should be yet
+		if len(files) == 0 {
+			logrus.WithFields(logrus.Fields{
+				"PodName": pod.Name,
+				"UID":     pod.UID,
+				"Path":    upath,
+			}).Info("insufficient information in pod log directory")
+			return "", fmt.Errorf("Could not determine log path for pod %s", pod.UID)
+		}
 		for _, f := range files {
 			if s, err := os.Stat(filepath.Join(upath, f)); err == nil {
 				// if we find at least one directory in the path, assume k8s

--- a/podtailer/podtailer_test.go
+++ b/podtailer/podtailer_test.go
@@ -26,6 +26,10 @@ func TestDetermineLogPatternK8S110(t *testing.T) {
 	assert.Nil(t, err)
 	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID)), 0777)
 	assert.Nil(t, err)
+
+	_, err = determineLogPattern(pod, path, false)
+	assert.Error(t, err, "determine log pattern should fail if pod dir has no files yet")
+
 	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID), "container1"), 0777)
 	assert.Nil(t, err)
 	err = os.Mkdir(filepath.Join(path, "pods", string(pod.UID), "container2"), 0777)

--- a/tailer/tailer_test.go
+++ b/tailer/tailer_test.go
@@ -113,7 +113,7 @@ func TestPathWatching(t *testing.T) {
 	handlerFactory := newMockLineHandlerFactory()
 
 	watcher := NewPathWatcher(
-		fmt.Sprintf("%s/*", dir),
+		func() (string, error) { return fmt.Sprintf("%s/*", dir), nil },
 		nil,
 		handlerFactory,
 		stateRecorder,
@@ -149,7 +149,7 @@ func TestPathWatching(t *testing.T) {
 
 	assert.Equal(t, len(handlerFactory.handlers), 2)
 	for _, h := range handlerFactory.handlers {
-		assert.Equal(t, len(h.lines), 2)
+		assert.Equal(t, 2, len(h.lines))
 	}
 	assert.Equal(t, len(watcher.tailers), 0)
 }


### PR DESCRIPTION
https://github.com/honeycombio/honeycomb-kubernetes-agent/pull/28 fixed an issue where new pods come up but get assigned the wrong log pattern since the directory structure is not there yet. Something we missed is that the pod directory can exist, but the contents may not yet exist. In this case, we fall back to the pre-K8s 1.10 format. This PR updates the determineLogPattern behavior to wait for either a file or directory to be present before making the version determination.

TODO: refactor all of this mess and somehow determine the log pattern based on the *actual* k8s version.