### PR TITLE
[processors] add a rename_field processor

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -111,6 +111,18 @@ key | value | description
 :--|:--|:--
 field | string | The name of the field to drop.
 
+### rename_field
+
+The `rename_field` processor will rename the specified field in all events, if it exists, before sending them to Honeycomb. You can use this to standardize field names across data sources, for example. Note that if the `new` field already exists, it will be overwritten with the value in the `original` field.
+
+**Options:**
+
+key | type | description
+:--|:--|:--
+original | string | Name of field to be renamed. Required.
+new | string | The new field name to use. Required.
+
+
 ### timefield
 The `timefield` processor will replace the default timestamp in an event with
 one extracted from a specific field in the event.

--- a/processors/processors.go
+++ b/processors/processors.go
@@ -20,7 +20,7 @@ type Processor interface {
 }
 
 // NewProcessorFromConfig takes a configuration map that's been unmarshalled
-// out of YAML, and tries to instantiate a corresponding parser.
+// out of YAML, and tries to instantiate a corresponding processor.
 // The syntax for processor configuration is:
 // processors:
 // - request_shape:
@@ -53,6 +53,8 @@ func NewProcessor(name string, options map[string]interface{}) (Processor, error
 		p = &Sampler{}
 	case "timefield":
 		p = &TimeFieldExtractor{}
+	case "rename_field":
+		p = &FieldRenamer{}
 	default:
 		return nil, fmt.Errorf("Unknown processor type %s", name)
 	}

--- a/processors/rename_field.go
+++ b/processors/rename_field.go
@@ -1,0 +1,49 @@
+package processors
+
+import (
+	"errors"
+
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/mitchellh/mapstructure"
+)
+
+var (
+	ErrFieldOptionUnspecified = errors.New("rename_field processor requires both 'new' and 'original' field names to be set")
+	ErrFieldOptionsMatch      = errors.New("rename_field processor does not support matching 'new' and 'original' field names")
+)
+
+type FieldRenamer struct {
+	config *fieldRenamerConfig
+}
+
+type fieldRenamerConfig struct {
+	Original string
+	New      string
+}
+
+func (f *FieldRenamer) Init(options map[string]interface{}) error {
+	config := &fieldRenamerConfig{}
+	err := mapstructure.Decode(options, config)
+	if err != nil {
+		return err
+	}
+
+	if config.New == "" || config.Original == "" {
+		return ErrFieldOptionUnspecified
+	}
+	if config.New == config.Original {
+		return ErrFieldOptionsMatch
+	}
+	f.config = config
+	return nil
+}
+
+func (f *FieldRenamer) Process(ev *event.Event) bool {
+	if ev.Data != nil {
+		if field_data, found := ev.Data[f.config.Original]; found {
+			ev.Data[f.config.New] = field_data
+			delete(ev.Data, f.config.Original)
+		}
+	}
+	return true
+}

--- a/processors/rename_field_test.go
+++ b/processors/rename_field_test.go
@@ -1,0 +1,76 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenameField(t *testing.T) {
+	// ensures FieldRenamer implements the Processor interface
+	var processor Processor
+	processor = &FieldRenamer{}
+
+	err := processor.Init(map[string]interface{}{
+		"original": "time",
+		"new":      "timestamp",
+	})
+	assert.Equal(t, nil, err, "init should not error")
+
+	e := &event.Event{
+		Data: map[string]interface{}{
+			"time": "tomorrow",
+			"msg":  "leave me be",
+		},
+	}
+	cont := processor.Process(e)
+	assert.Equal(t, true, cont, "Process should return true, to signal continued processing")
+	assert.Equal(t, nil, e.Data["time"], "time field should be removed")
+	assert.Equal(t, "tomorrow", e.Data["timestamp"], "timestamp field should be present")
+	assert.Equal(t, "leave me be", e.Data["msg"], "msg field should be unchanged")
+
+	// we should not crash if no data is present
+	cont = processor.Process(&event.Event{Data: map[string]interface{}{}})
+	assert.Equal(t, true, cont, "Process should return true, to signal continued processing")
+}
+
+func TestRenameFieldOverwritesExisting(t *testing.T) {
+	// ensures FieldRenamer implements the Processor interface
+	var processor Processor
+	processor = &FieldRenamer{}
+
+	err := processor.Init(map[string]interface{}{
+		"original": "time",
+		"new":      "timestamp",
+	})
+	assert.Equal(t, nil, err, "init should not error")
+
+	e := &event.Event{
+		Data: map[string]interface{}{
+			"time":      "tomorrow",
+			"timestamp": "yesterday",
+		},
+	}
+	cont := processor.Process(e)
+	assert.Equal(t, true, cont, "Process should return true, to signal continued processing")
+	assert.Equal(t, nil, e.Data["time"], "time field should be removed")
+	assert.Equal(t, "tomorrow", e.Data["timestamp"], "timestamp field should have new value")
+}
+
+func TestRenameFieldInvalidConfig(t *testing.T) {
+	processor := &FieldRenamer{}
+	err := processor.Init(map[string]interface{}{
+		"original": "time",
+		"new":      "time",
+	})
+	assert.Equal(t, ErrFieldOptionsMatch, err, "matching new and original field names should return an error")
+	err = processor.Init(map[string]interface{}{
+		"original": "time",
+	})
+	assert.Equal(t, ErrFieldOptionUnspecified, err, "an error should be returned if new is not specified")
+	err = processor.Init(map[string]interface{}{
+		"new": "time",
+	})
+	assert.Equal(t, ErrFieldOptionUnspecified, err, "an error shuould be returned if original is not specified")
+}


### PR DESCRIPTION
Addresses https://github.com/honeycombio/honeycomb-kubernetes-agent/issues/36

Adds a `rename_field` processor to enable renaming fields before events are sent to Honeycomb.

Ran this on my minikube cluster with a sample service:
![image](https://user-images.githubusercontent.com/3129677/56314402-d2c16380-6109-11e9-83b3-e9646508e098.png)
