### PR TITLE
processors: Add a pair of simple filter processors

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -129,6 +129,7 @@ keys | list of strings | The list of field keys to use when doing dynamic sampli
 windowSize | int | How often to refresh estimated sample rates when doing dynamic sampling, in seconds. Defaults to 30 seconds.
 
 ### drop_field
+
 The `drop_field` processor will remove the specified field from all events before sending them to Honeycomb. This is useful for removing sensitive information from events.
 
 **Options:**
@@ -136,6 +137,37 @@ The `drop_field` processor will remove the specified field from all events befor
 key | value | description
 :--|:--|:--
 field | string | The name of the field to drop.
+
+### drop_event
+
+The `drop_event` processor will remove all events where the specified field
+exactly matches one of the listed values.
+This can be used to filter datasets from ingress to service based on which
+service or namespace is used.
+
+Events that do not have a key named `field` present will be kept.
+
+**Options:**
+key | value | description
+:--|:--|:--
+field | string | The name of the field to look into
+values | list  | A list of string values to match with
+
+### keep_event
+
+The `keep_event` processor will remove all events NOT matching one of the
+specified values. Careless configuration of this filter will drop all events.
+
+It is effectively the inverse of `drop_event`.
+
+Events that do not have a key named `field` present will be kept to avoid
+accidental data loss.
+
+**Options:**
+key | value | description
+:--|:--|:--
+field | string | The name of the field to look into
+values | list  | A list of string values to match with
 
 ### rename_field
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -141,33 +141,35 @@ field | string | The name of the field to drop.
 ### drop_event
 
 The `drop_event` processor will remove all events where the specified field
-exactly matches one of the listed values.
-This can be used to filter datasets from ingress to service based on which
-service or namespace is used.
+exactly matches one of the values in the blacklist.
 
-Events that do not have a key named `field` present will be kept.
+This can be used to filter datasets from _Ingress_ to _Service_ based on which
+_Service_ or _Namespace_ is used.
+
+Events that do not have a `field` matching this configuration will be kept.
 
 **Options:**
 key | value | description
 :--|:--|:--
-field | string | The name of the field to look into
-values | list  | A list of string values to match with
+field | string | The name of the event field to match against the blacklist
+values | list  | The set of field values that cause this processor to drop an event
+
 
 ### keep_event
 
 The `keep_event` processor will remove all events NOT matching one of the
-specified values. Careless configuration of this filter will drop all events.
+whitelisted values. Careless configuration of this filter will drop all events.
 
 It is effectively the inverse of `drop_event`.
 
-Events that do not have a key named `field` present will be kept to avoid
-accidental data loss.
+Events that do not have a `field` matching the configuration will be kept to
+avoid accidental data loss.
 
 **Options:**
 key | value | description
 :--|:--|:--
-field | string | The name of the field to look into
-values | list  | A list of string values to match with
+field | string | The name of the field to match against the whitelist
+values | list  | The name of the event field to match against the whitelist
 
 ### rename_field
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -440,7 +440,6 @@ func TestRenameField(t *testing.T) {
 	assert.Equal(t, mt.events[0], expected)
 }
 
-
 func TestEventDropper(t *testing.T) {
 	mt := &MockTransmitter{}
 
@@ -459,16 +458,23 @@ processors:
 	handler := hf.New("/tmp/testpath")
 	handler.Handle(`{"service": "dropthis", "another": "field"}`)
 	handler.Handle(`{"service": "keepme", "another": "field"}`)
-	assert.Equal(t, len(mt.events), 1)
-	expected := &event.Event{
+	handler.Handle(`{"no_service": "keepme", "another": "field"}`)
+	assert.Equal(t, len(mt.events), 2)
+	expected0 := &event.Event{
 		Data:       map[string]interface{}{"service": "keepme", "another": "field"},
 		Dataset:    "kubernetestest",
 		Path:       "/tmp/testpath",
 		RawMessage: `{"service": "keepme", "another": "field"}`,
 	}
-	assert.Equal(t, mt.events[0], expected)
+	expected1 := &event.Event{
+		Data:       map[string]interface{}{"no_service": "keepme", "another": "field"},
+		Dataset:    "kubernetestest",
+		Path:       "/tmp/testpath",
+		RawMessage: `{"no_service": "keepme", "another": "field"}`,
+	}
+	assert.Equal(t, mt.events[0], expected0)
+	assert.Equal(t, mt.events[1], expected1)
 }
-
 
 func TestEventKeeper(t *testing.T) {
 	mt := &MockTransmitter{}
@@ -488,16 +494,23 @@ processors:
 	handler := hf.New("/tmp/testpath")
 	handler.Handle(`{"service": "dropthis", "another": "field"}`)
 	handler.Handle(`{"service": "keepme", "another": "field"}`)
-	assert.Equal(t, len(mt.events), 1)
-	expected := &event.Event{
+	handler.Handle(`{"no_service": "keepme", "another": "field"}`)
+	assert.Equal(t, len(mt.events), 2)
+	expected0 := &event.Event{
 		Data:       map[string]interface{}{"service": "keepme", "another": "field"},
 		Dataset:    "kubernetestest",
 		Path:       "/tmp/testpath",
 		RawMessage: `{"service": "keepme", "another": "field"}`,
 	}
-	assert.Equal(t, mt.events[0], expected)
+	expected1 := &event.Event{
+		Data:       map[string]interface{}{"no_service": "keepme", "another": "field"},
+		Dataset:    "kubernetestest",
+		Path:       "/tmp/testpath",
+		RawMessage: `{"no_service": "keepme", "another": "field"}`,
+	}
+	assert.Equal(t, mt.events[0], expected0)
+	assert.Equal(t, mt.events[1], expected1)
 }
-
 
 func TestStaticSampling(t *testing.T) {
 	mt := &MockTransmitter{}

--- a/processors/drop_event.go
+++ b/processors/drop_event.go
@@ -56,6 +56,7 @@ func (f *EventDropper) Process(ev *event.Event) bool {
 			"value": val,
 			"type":  fmt.Sprintf("%T", val)}).
 			Debug("Not filtering field of non-string type")
+		return true
 	}
 	_, exists := f.values[valString]
 	return !exists

--- a/processors/drop_event.go
+++ b/processors/drop_event.go
@@ -1,0 +1,64 @@
+package processors
+
+import (
+	"errors"
+
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrFilterOptionUnspecified = errors.New("drop_event processor requires a 'Field' to be set")
+)
+
+type EventDropper struct {
+	config *eventDropperConfig
+	values map[string]bool
+}
+
+type eventDropperConfig struct {
+	Field  string
+	Values []string
+}
+
+func (f *EventDropper) Init(options map[string]interface{}) error {
+	config := &eventDropperConfig{}
+	err := mapstructure.Decode(options, config)
+	if err != nil {
+		return err
+	}
+
+	if config.Field == "" {
+		return ErrFilterOptionUnspecified
+	}
+	f.config = config
+
+	values := make(map[string]bool)
+	for _, val := range f.config.Values {
+		values[val] = true
+	}
+	f.values = values
+	return nil
+}
+
+func (f *EventDropper) Process(ev *event.Event) bool {
+	if ev.Data != nil {
+		val, ok := ev.Data[f.config.Field]
+		if !ok {
+			return true
+		}
+		valString, ok := val.(string)
+		if !ok {
+			logrus.WithFields(logrus.Fields{
+				"key":   f.config.Field,
+				"value": val}).
+				Debug("Not filtering field of non-string type")
+		}
+		_, exists := f.values[valString]
+		if exists {
+			return false
+		}
+	}
+	return true
+}

--- a/processors/keep_event.go
+++ b/processors/keep_event.go
@@ -54,6 +54,7 @@ func (f *EventKeeper) Process(ev *event.Event) bool {
 			"type":  fmt.Sprintf("%T", val),
 		}).
 			Debug("Not filtering field of non-string type")
+		return true
 	}
 	_, exists := f.values[valString]
 	return exists

--- a/processors/keep_event.go
+++ b/processors/keep_event.go
@@ -1,0 +1,59 @@
+package processors
+
+import (
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+)
+
+type EventKeeper struct {
+	config *eventKeeperConfig
+	values map[string]bool
+}
+
+type eventKeeperConfig struct {
+	Field  string
+	Values []string
+}
+
+func (f *EventKeeper) Init(options map[string]interface{}) error {
+	config := &eventKeeperConfig{}
+	err := mapstructure.Decode(options, config)
+	if err != nil {
+		return err
+	}
+
+	if config.Field == "" {
+		return ErrFilterOptionUnspecified
+	}
+	f.config = config
+
+	values := make(map[string]bool)
+	for _, val := range f.config.Values {
+		values[val] = true
+	}
+	f.values = values
+	return nil
+}
+
+func (f *EventKeeper) Process(ev *event.Event) bool {
+	if ev.Data != nil {
+		val, ok := ev.Data[f.config.Field]
+		if !ok {
+			return true
+		}
+		valString, ok := val.(string)
+		if !ok {
+			logrus.WithFields(logrus.Fields{
+				"key":   f.config.Field,
+				"value": val}).
+				Debug("Not filtering field of non-string type")
+		}
+		_, exists := f.values[valString]
+		if exists {
+			return true
+		}
+		return false
+	}
+	return true
+}

--- a/processors/processors.go
+++ b/processors/processors.go
@@ -49,6 +49,10 @@ func NewProcessor(name string, options map[string]interface{}) (Processor, error
 		p = &RequestShaper{}
 	case "drop_field":
 		p = &FieldDropper{}
+	case "drop_event":
+		p = &EventDropper{}
+	case "keep_event":
+		p = &EventKeeper{}
 	case "sample":
 		p = &Sampler{}
 	case "timefield":


### PR DESCRIPTION
This filters events based on exact matches of key:values, in the form of two
basic processors.

keep_event:
  Matches a single key to one of a series of values, and
  keeps only events matching this value.

drop_event:
  Matches a single key to one of a series of values, and drops all events matching
  this value

These are intended as processor filters from things like the `nginx-ingress`
which contains data from one or more datasets, which should be split out based
on some pre-configured conditions.

Typical usecase was to filter on the k8s.service or a specific hostname.

It only performs exact string matches, as it is not intended to be a generic
filter or routing implementation.