### PR TITLE
Upgrade to the GA version of DaemonSet

### DIFF
--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -59,7 +59,7 @@ data:
 
 # Daemonset
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -69,6 +69,9 @@ metadata:
   name: honeycomb-agent-v1.5.0
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: honeycomb-agent
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
The extensions API version of DaemonSet has been deprecated.
Upgrade to `apps/v1` and add the mandatory `selector` configuration.