### PR TITLE
Fix flaky tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config-test.yaml
 /.dockerfile-*
 kind
 .kube
+.idea/**

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -638,7 +638,7 @@ processors:
 	for _, ev := range mt.events {
 		countsByKey[ev.Data["sampleKey"].(string)]++
 	}
-	assert.InDelta(t, countsByKey["a"], count/10, 500)
+	assert.InDelta(t, countsByKey["a"], count/10, float64(count/10)*0.05)
 	for i := 0; i < 100; i++ {
 		assert.Equal(t, countsByKey[fmt.Sprintf("%d", i)], 1)
 	}

--- a/tailer/tailer_test.go
+++ b/tailer/tailer_test.go
@@ -122,7 +122,7 @@ func TestPathWatching(t *testing.T) {
 		stateRecorder,
 	)
 
-	watcher.checkInterval = time.Millisecond
+	watcher.checkInterval = 100 * time.Millisecond
 	watcher.Start()
 
 	err = os.MkdirAll(dir, os.FileMode(0755))


### PR DESCRIPTION
Fixes the 2 flaky tests that randomly fail.

- TestPathWatching now uses a 100ms watcher instead of 1ms
- TestDynamicSampling asserts on a 5% delta of target sampled instead of static value (500)
