### PR TITLE
fix: Prevent index out of range exceptions when attempting to infer datatypes from short strings

### DIFF
--- a/unwrappers/unwrappers.go
+++ b/unwrappers/unwrappers.go
@@ -20,10 +20,10 @@ type InferUnwrapper struct{
 }
 
 func (w *InferUnwrapper) Unwrap(s string, p parsers.Parser) (*event.Event, error) {
-	if s[0] == '{' {
+	if len(s) > 0 && s[0] == '{' {
 		// Scan for the start of a JSON blob.
 		return w.json.Unwrap(s, p)
-	} else if s[4] == '-' && s[7] == '-' && s[10] == 'T' {
+	} else if len(s) > 10 && s[4] == '-' && s[7] == '-' && s[10] == 'T' {
 		// Scan for what looks like an RFC3339 timestamp.
 		return w.cri.Unwrap(s, p)
 	} else {


### PR DESCRIPTION
# Description
This ensures that a string is long enough before testing runes within it, preventing
situations where we attempt to test  `s[0]` in an empty string, or `s[4]` in a string
with fewer than 5 characters in it.

This prevents a `panic: runtime error: index out of range [0] with length 0` crash.

## Exception
```
2020-10-03T20:51:38.477797603Z panic: runtime error: index out of range [0] with length 0
2020-10-03T20:51:38.477811803Z 
2020-10-03T20:51:38.477817603Z goroutine 138 [running]:
2020-10-03T20:51:38.477822003Z github.com/honeycombio/honeycomb-kubernetes-agent/unwrappers.(*InferUnwrapper).Unwrap(0x1d01ca0, 0x1c6f1ca, 0x0, 0x14094c0, 0x1d01ca0, 0xc00067eba0, 0xc000161f40, 0xc0009f73e0)
2020-10-03T20:51:38.477826503Z 	/home/circleci/project/unwrappers/unwrappers.go:23 +0x1a6
2020-10-03T20:51:38.477830304Z github.com/honeycombio/honeycomb-kubernetes-agent/handlers.(*LineHandlerImpl).Handle(0xc00010ecc0, 0x1c6f1ca, 0x0)
2020-10-03T20:51:38.477854204Z 	/home/circleci/project/handlers/handlers.go:97 +0x75
2020-10-03T20:51:38.477858904Z github.com/honeycombio/honeycomb-kubernetes-agent/tailer.(*Tailer).Run.func1(0xc00012c2c0, 0xc0008e3040, 0xc0009280a0)
2020-10-03T20:51:38.477862704Z 	/home/circleci/project/tailer/tailer.go:79 +0x146
2020-10-03T20:51:38.477866404Z created by github.com/honeycombio/honeycomb-kubernetes-agent/tailer.(*Tailer).Run
2020-10-03T20:51:38.477871904Z 	/home/circleci/project/tailer/tailer.go:67 +0x34b
```