### PR TITLE
Update quickstart to use latest version of image

### DIFF
--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -106,7 +106,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: honeycombio/honeycomb-kubernetes-agent:2.1.2
+        image: honeycombio/honeycomb-kubernetes-agent:2.1.3
         imagePullPolicy: IfNotPresent
         name: honeycomb-agent
         resources:


### PR DESCRIPTION
Keep the image references in the example quickstart with the latest release version