### PR TITLE
Adding the agent collection interval as an event field

### DIFF
--- a/service/runnable.go
+++ b/service/runnable.go
@@ -124,6 +124,8 @@ func (r *runnable) Run() error {
 			ev.AddField(pre+k, val)
 		}
 
+		ev.AddField("agent.interval.seconds", r.interval.Seconds())
+
 		r.logger.WithFields(logrus.Fields{
 			"resourceType": rm.Resource.Type,
 			"resourceName": rm.Resource.Name,


### PR DESCRIPTION
This adds an additional field into each event to capture the interval duration in seconds. It's helpful to have this information for users to understand the collection rate.

Not 100% sold on the name of the field. Would this be better as `metrics.interval.seconds`?