### PR TITLE
Ismith.multiarch docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,58 @@ tag_filters: &tag_filters
         only: /.*/
 
 jobs:
-  build_agent:
+  deploy_join:
+    parameters:
+      manifest_tool_version:
+        type: string
+        default: "1.0.3"
     docker:
-      - image: cimg/go:1.15.8
+      - image: cimg/python:3.9.5
+    steps:
+      - checkout
+      - restore_cache:
+          key: manifest-tool-v1-<< parameters.manifest_tool_version >>
+      - run:
+          name: Install manifest tool
+          command: |
+            set -euo pipefail
+            set -x
+
+            manifest_tool_version=<< parameters.manifest_tool_version >>
+
+            if ! ( command -v manifest-tool ); then
+              if [[ $(uname -m) == aarch64 ]]; then
+                arch=arm64
+              else
+                arch=amd64
+              fi
+
+              curl -L -o manifest-tool https://github.com/estesp/manifest-tool/releases/download/v${manifest_tool_version}/manifest-tool-linux-${arch}
+              chmod +x manifest-tool
+            fi
+      - save_cache:
+          key: manifest-tool-v1-<< parameters.manifest_tool_version >>
+          paths:
+            - manifest-tool
+
+      - run: make manifest-push
+
+  build_agent:
+    parameters:
+      arch:
+        type: string
+      resource_class:
+        type: string
+    machine:
+      image: ubuntu-2004:202101-01
+      resource_class: << parameters.resource_class >>
     # needed to build docker images, attach mount points, etc
     steps:
       - checkout
-      - setup_remote_docker
       - run: make container
       - run: make test
       - run: e2e-tests/test.sh
+      # TODO
       - run:
           name: "Deploy on tagged master push"
           command: |
@@ -35,4 +77,18 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build_agent: *tag_filters
+      - build_agent:
+        << *tag_filters
+          name: build_agent_amd64
+          arch: amd64
+          resource_class: large
+      - build_agent:
+        << *tag_filters
+          name: build_agent_arm64
+          arch: arm64
+          resource_class: arm.large
+      - push_multiarch_manifest:
+        << *tag_filters
+        require:
+          - build_agent_amd64
+          - build_agent_arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,39 +10,19 @@ tag_filters: &tag_filters
 jobs:
   deploy_join:
     parameters:
-      manifest_tool_version:
-        type: string
-        default: "1.0.3"
     docker:
       - image: cimg/python:3.9.5
     steps:
       - checkout
-      - restore_cache:
-          key: manifest-tool-v1-<< parameters.manifest_tool_version >>
       - run:
-          name: Install manifest tool
+          name: "Deploy on tagged master push"
           command: |
-            set -euo pipefail
-            set -x
-
-            manifest_tool_version=<< parameters.manifest_tool_version >>
-
-            if ! ( command -v manifest-tool ); then
-              if [[ $(uname -m) == aarch64 ]]; then
-                arch=arm64
-              else
-                arch=amd64
-              fi
-
-              curl -L -o manifest-tool https://github.com/estesp/manifest-tool/releases/download/v${manifest_tool_version}/manifest-tool-linux-${arch}
-              chmod +x manifest-tool
-            fi
-      - save_cache:
-          key: manifest-tool-v1-<< parameters.manifest_tool_version >>
-          paths:
-            - manifest-tool
-
-      - run: make manifest-push
+            if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -z "${CIRCLE_BRANCH}" ] && [ -n "${CIRCLE_TAG}" ]; then
+              echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+              make manifest;
+            else
+              echo "skipping push. CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}, CIRCLE_BRANCH=${CIRCLE_BRANCH}, CIRCLE_TAG=${CIRCLE_TAG}"
+            fi;
 
   build_agent:
     parameters:
@@ -56,10 +36,9 @@ jobs:
     # needed to build docker images, attach mount points, etc
     steps:
       - checkout
-      - run: make container
-      - run: make test
+      - run: make container-<< parameters.arch >>
+      - run: make test-<< parameters.arch >>
       - run: e2e-tests/test.sh
-      # TODO
       - run:
           name: "Deploy on tagged master push"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout
       - run: make container-<< parameters.arch >>
-      - run: make test-<< parameters.arch >>
+      - run: make test
       - run: e2e-tests/test.sh
       - run:
           name: "Deploy on tagged master push"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@ tag_filters: &tag_filters
         only: /.*/
 
 jobs:
-  deploy_join:
-    parameters:
+  push_multiarch_manifest:
     docker:
       - image: cimg/python:3.9.5
     steps:
@@ -57,17 +56,17 @@ workflows:
   build_and_deploy:
     jobs:
       - build_agent:
-        << *tag_filters
+          <<: *tag_filters
           name: build_agent_amd64
           arch: amd64
           resource_class: large
       - build_agent:
-        << *tag_filters
+          <<: *tag_filters
           name: build_agent_arm64
           arch: arm64
           resource_class: arm.large
       - push_multiarch_manifest:
-        << *tag_filters
-        require:
-          - build_agent_amd64
-          - build_agent_arm64
+          <<: *tag_filters
+          requires:
+            - build_agent_amd64
+            - build_agent_arm64

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ push: .push-$(DOTFILE_IMAGE) push-name
 	@docker images -q $(IMAGE):$(VERSION)-$(ARCH) > $@
 
 push-name:
-	@echo "pushed: $(IMAGE):$(VERSION)"
+	@echo "pushed: $(IMAGE):$(VERSION)-$(ARCH)"
 
 # Push the image tagged with :head
 push-head:
-	@docker tag $(IMAGE):$(VERSION) $(IMAGE)-$(ARCH):head-$(ARCH)
+	@docker tag $(IMAGE)-$(VERSION)-$(ARCH):head-$(ARCH)
 	@docker push $(IMAGE):head-$(ARCH)
 	@echo "pushed: $(IMAGE):head-$(ARCH)"
 
@@ -118,9 +118,10 @@ container-clean:
 bin-clean:
 	rm -rf bin
 
-# If any of the inputs (arm64, amd64) is missing, manifest-tool will terminate
-# with an error like: `FATA[0001] Inspect of image
-# registry.docker.com/$(image):$(version)-amd64"
-# failed with error: manifest unknown: Requested image not found`
-manifest-push:
-	manifest-tool push from-args --platforms linux/amd64,linux-arm64 --template $(VERSION)-ARCH --target $(VERSION)
+manifest:
+	docker manifest create $(IMAGE):$(VERSION) $(IMAGE)-$(VERSION)-amd64 $(IMAGE):$(VERSION)-arm64
+	docker manifest oush $(IMAGE):$(VERSION)
+
+manifest:
+	docker manifest create $(IMAGE):head $(IMAGE)-$(VERSION)-amd64 $(IMAGE):$(VERSION)-arm64
+	docker manifest oush $(IMAGE):head


### PR DESCRIPTION
**Goals:**
honeycombio/honeycomb-kubernetes-agent should be a multiarch (linux/amd64, linux/arm64) image

**TBD**:
- Do we need to create new repos for honeycomb-kubernetes-agent-amd64 and honeycomb-kubernetes-agent-arm64?
- does Circle's docker version have the `manifest` command?  Do we need to set an experimental flag?