### PR TITLE
Fix base selector for logs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,12 +104,12 @@ kube-scheduler-docker-for-desktop            1/1       Running   1          5d
 
 To view the events and describe the pod you can run, this has a lot of useful information:
 ```
-$ kubectl describe pods --namespace=kube-system --selector=k8s-app=honeycomb-agent
+$ kubectl describe pods --namespace=kube-system --selector=app=honeycomb-agent
 ```
 
 To view logs you can run:
 ```
-kubectl logs --namespace=kube-system --selector=k8s-app=honeycomb-agent
+kubectl logs --namespace=kube-system --selector=app=honeycomb-agent
 ```
 
 ##### For iterative local changes
@@ -250,8 +250,8 @@ $ kubectl apply -f quickstart.yaml
 **7. Check the logs, poke around, verify your code, etc**
 
 ```bash
-$ kubectl logs -l k8s-app=honeycomb-agent
-time="2018-11-09T22:01:48Z" level=debug msg="Starting informer" fieldSelector="spec.nodeName=minikube" labelSelector="k8s-app=kube-controller-manager,k8s-app!=honeycomb-agent" namespace=kube-system
-time="2018-11-09T22:01:48Z" level=debug msg="Starting informer" fieldSelector="spec.nodeName=minikube" labelSelector="app=guestbook,k8s-app!=honeycomb-agent" namespace=default
+$ kubectl logs -l app=honeycomb-agent
+time="2018-11-09T22:01:48Z" level=debug msg="Starting informer" fieldSelector="spec.nodeName=minikube" labelSelector="component=kube-controller-manager,app!=honeycomb-agent" namespace=kube-system
+time="2018-11-09T22:01:48Z" level=debug msg="Starting informer" fieldSelector="spec.nodeName=minikube" labelSelector="app=guestbook,app!=honeycomb-agent" namespace=default
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following steps will deploy the Honeycomb agent to each node in your cluster
 
 1. Grab your Honeycomb writekey from your [account page](https://ui.honeycomb.io/account), and create a Kubernetes secret from it:
     ```
-    kubectl create secret generic honeycomb-writekey --from-literal=api-key=$WRITEKEY --namespace=honeycomb
+    kubectl create secret generic honeycomb --from-literal=api-key=$WRITEKEY --namespace=honeycomb
     ```
 
 2.  Run the agent

--- a/e2e-tests/internal/test_internal.sh
+++ b/e2e-tests/internal/test_internal.sh
@@ -49,7 +49,7 @@ count=$(echo $ret | jq ".kubernetestest | length")
 if [ $count -ne 1 ]; then
     echo "Didn't receive expected number of events!"
     echo "agent logs:"
-    kubectl logs -n kube-system -l k8s-app=honeycomb-agent
+    kubectl logs -n kube-system -l app=honeycomb-agent
     exit 1
 fi
 kubectl delete pod,svc --all

--- a/e2e-tests/internal/testspec.yaml
+++ b/e2e-tests/internal/testspec.yaml
@@ -55,7 +55,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    k8s-app: honeycomb-agent
+    app: honeycomb-agent
     kubernetes.io/cluster-service: 'true'
     version: v1.1
   name: honeycomb-agent-v1.1
@@ -63,11 +63,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: honeycomb-agent
+      app: honeycomb-agent
   template:
     metadata:
       labels:
-        k8s-app: honeycomb-agent
+        app: honeycomb-agent
         kubernetes.io/cluster-service: 'true'
         version: v1.1
     spec:

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -98,7 +98,7 @@ spec:
   template:
     metadata:
       labels:
-        akcupp: honeycomb-agent
+        app: honeycomb-agent
     spec:
       tolerations:
         - operator: Exists

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -48,11 +48,23 @@ data:
     apiHost: https://api.honeycomb.io/
     watchers:
       - dataset: kubernetes-logs
-        labelSelector: component=kube-controller-manager,tier=control-plane
+        labelSelector: "component=kube-apiserver,tier=control-plane"
         namespace: kube-system
         parser: glog
       - dataset: kubernetes-logs
-        labelSelector: component=kube-scheduler,tier=control-plane
+        labelSelector: "component=kube-scheduler,tier=control-plane"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "component=kube-controller-manager,tier=control-plane"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-proxy"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-dns"
         namespace: kube-system
         parser: glog
     verbosity: info
@@ -86,7 +98,7 @@ spec:
   template:
     metadata:
       labels:
-        app: honeycomb-agent
+        akcupp: honeycomb-agent
     spec:
       tolerations:
         - operator: Exists

--- a/podtailer/podtailer.go
+++ b/podtailer/podtailer.go
@@ -66,10 +66,11 @@ func (pt *PodSetTailer) run() {
 	defer pt.wg.Done()
 	labelSelector := *pt.config.LabelSelector
 	// Exclude the agent's own logs from being watched
+	// This is quasi-hack. Though we recommend the use of the `app: honeycomb-agent` label, this can't be enforced.
 	if labelSelector == "" {
-		labelSelector = "k8s-app!=honeycomb-agent"
+		labelSelector = "app!=honeycomb-agent"
 	} else {
-		labelSelector = labelSelector + ",k8s-app!=honeycomb-agent"
+		labelSelector = labelSelector + ",app!=honeycomb-agent"
 	}
 
 	podWatcher := k8sagent.NewPodWatcher(

--- a/smoketest/quickstart.yaml
+++ b/smoketest/quickstart.yaml
@@ -6,7 +6,7 @@ metadata:
   name: honeycomb-serviceaccount
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: honeycomb-serviceaccount
@@ -20,7 +20,7 @@ subjects:
   namespace: default
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: honeycomb-serviceaccount
   namespace: default
@@ -43,18 +43,18 @@ metadata:
 data:
   config.yaml: |-
     # By default, submit logs from interesting system pods such as the
-    # kube API server
+    # kube API server, scheduler, etc
     watchers:
       - dataset: kubernetes-logs
-        labelSelector: "k8s-app=kube-apiserver"
+        labelSelector: "component=kube-apiserver,tier=control-plane"
         namespace: kube-system
         parser: glog
       - dataset: kubernetes-logs
-        labelSelector: "k8s-app=kube-scheduler"
+        labelSelector: "component=kube-scheduler,tier=control-plane"
         namespace: kube-system
         parser: glog
       - dataset: kubernetes-logs
-        labelSelector: "k8s-app=kube-controller-manager"
+        labelSelector: "component=kube-controller-manager,tier=control-plane"
         namespace: kube-system
         parser: glog
       - dataset: kubernetes-logs
@@ -62,7 +62,7 @@ data:
         namespace: kube-system
         parser: glog
       - dataset: kubernetes-logs
-        labelSelector: "k8s-app=dns-controller"
+        labelSelector: "k8s-app=kube-dns"
         namespace: kube-system
         parser: glog
       - dataset: frontend
@@ -76,16 +76,19 @@ data:
 
 # Daemonset
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    k8s-app: honeycomb-agent
+    app: honeycomb-agent
     kubernetes.io/cluster-service: 'true'
     version: v1.1
-  name: honeycomb-agent-v1.1
+  name: honeycomb-agent
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: honeycomb-agent
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -93,7 +96,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: honeycomb-agent
+        app: honeycomb-agent
         kubernetes.io/cluster-service: 'true'
         version: v1.1
     spec:


### PR DESCRIPTION
This PR forces the app to use the proper base selector label or `app` instead of `k8s-app` for deployment.  

The quickstart.yaml was also updated to reflect this change, and specify proper labels for default k8s components.