### PR TITLE
fix: container metadata missing

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -759,7 +759,7 @@ func TestKubernetesMetadata(t *testing.T) {
 	hf, err := NewLineHandlerFactoryFromConfig(cfg, &unwrappers.RawLogUnwrapper{}, mt, k8sProcessor)
 	assert.NoError(t, err)
 
-	handler := hf.New("/var/log/pods/examplePodUID/container_0.log")
+	handler := hf.New("/var/log/pods/examplePodUID/container/0.log")
 	handler.Handle(`{"field": "a"}`)
 	assert.Equal(t, len(mt.events), 1)
 

--- a/processors/kubernetes.go
+++ b/processors/kubernetes.go
@@ -1,7 +1,6 @@
 package processors
 
 import (
-	"path"
 	"regexp"
 
 	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
@@ -68,14 +67,13 @@ func extractMetadataFromPod(pod *v1.Pod, containerName string) map[string]interf
 }
 
 func getContainerNameFromPath(filePath string) string {
-	r := regexp.MustCompile("(?P<name>.*)_[0-9]+.log")
-	filename := path.Base(filePath)
-	match := r.FindStringSubmatch(filename)
+	r := regexp.MustCompile("/var/log/pods/(.*)/(?P<name>.*)/[0-9]+.log")
+	match := r.FindStringSubmatch(filePath)
 	if match == nil {
 		return ""
 	}
-	if len(match) < 2 {
+	if len(match) < 3 {
 		return ""
 	}
-	return match[1]
+	return match[2]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- container logs path changed since this regex was written in 2017
- closes #196 

## Short description of the changes

- this is still quite brittle, but at least no longer broken
- added #197 to cover this in e2e tests
