### PR TITLE
maint: update releasing notes for ci workflow and helm chart update

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,10 @@
 # Creating a new release
 
-1. Update the version string in `version.txt`. Update the version in quickstart.yaml.
-2. Add new release notes to `CHANGELOG.md`.
-4. Open a PR with those changes, and await for it to be approved, then merge it.
-5. Create a new Release with proper release notes. Add a tag to the release in the following format: `v1.2.3`.
-6. This will kick off a CI workflow, which will package and publish the image to Docker Hub.
+1. Update the version string in `version.txt`.
+2. Update the version in `quickstart.yaml`.
+3. Add new release notes to `CHANGELOG.md`.
+4. Commit changes, push, and open a release preparation pull request for review
+5. Once the pull request is approved and merged, fetch the updated `main` branch
+6. Add a tag to the `main` branch with the new version in the following format: `v1.2.3`.
+7. Push the new version tag up to the project repository to kick off the CI workflow, which will package and publish the image to Docker Hub.
+8. Update the Draft Release with proper release notes (copied from CHANGELOG or auto-generated).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,3 +8,4 @@
 6. Add a tag to the `main` branch with the new version in the following format: `v1.2.3`.
 7. Push the new version tag up to the project repository to kick off the CI workflow, which will package and publish the image to Docker Hub.
 8. Update the Draft Release with proper release notes (copied from CHANGELOG or auto-generated).
+9. Update the [Honeycomb Helm Chart](https://github.com/honeycombio/helm-charts/tree/main/charts/honeycomb) with the changes

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -118,7 +118,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: honeycombio/honeycomb-kubernetes-agent:2.2.0
+        image: honeycombio/honeycomb-kubernetes-agent:2.2.1
         imagePullPolicy: IfNotPresent
         name: honeycomb-agent
         resources:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

Update `RELEASING.md` steps to match the new workflow.

- Tag for release. PR #194 updated CircleCI workflow to create draft release upon tagging, and PR #201 for the last release confirmed the new process works
- Split out version change for quickstart example to avoid accidental overlooking.
- Add note/reminder to update corresponding helm-chart
