### PR TITLE
maint: fix test step in circle ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run: go install github.com/google/ko@latest
       - run: echo "VERSION=$(cat version.txt | tr -d '\n')" >> $BASH_ENV
       - run: ./build/build.sh
-      - run: ./build/test.sh
+      - run: ./build/test.sh .
       - run: e2e-tests/test.sh
       - run:
           name: "Deploy on tagged master push"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #213 

## Short description of the changes

- When the test script was moved from Makefile to Circle config file, the `.` specifying the directory was missing so the script was not running through subdirectories to find tests.

Compare test output from before:

```
Running unit tests:
?   	github.com/honeycombio/honeycomb-kubernetes-agent	[no test files]

Checking go vet:
PASS
```

to confirm it's working now:

```
Running unit tests:
go: downloading github.com/stretchr/testify v1.7.0
go: downloading github.com/pmezard/go-difflib v1.0.0
?   	github.com/honeycombio/honeycomb-kubernetes-agent	[no test files]
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/config	0.007s
?   	github.com/honeycombio/honeycomb-kubernetes-agent/event	[no test files]
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/handlers	2.086s
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/interval	0.002s
?   	github.com/honeycombio/honeycomb-kubernetes-agent/k8sagent	[no test files]
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/kubelet	0.190s
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/metrics	7.115s
?   	github.com/honeycombio/honeycomb-kubernetes-agent/metrics/mock	[no test files]
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/parsers	0.007s
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/podtailer	0.014s
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/processors	0.010s
?   	github.com/honeycombio/honeycomb-kubernetes-agent/service	[no test files]
ok  	github.com/honeycombio/honeycomb-kubernetes-agent/tailer	4.108s
?   	github.com/honeycombio/honeycomb-kubernetes-agent/transmission	[no test files]
?   	github.com/honeycombio/honeycomb-kubernetes-agent/unwrappers	[no test files]
?   	github.com/honeycombio/honeycomb-kubernetes-agent/version	[no test files]

Checking go vet:
PASS
```

