### PR TITLE
fix nil pointer dereference in runnable.go with includeNodeLabels

### DIFF
--- a/service/runnable.go
+++ b/service/runnable.go
@@ -47,6 +47,7 @@ func newRunnable(rc kubelet.RestClient, builder *libhoney.Builder, opt Options, 
 		includeNodeLabels:     opt.IncludeNodeLabels,
 		metricGroupsToCollect: opt.MetricGroupsToCollect,
 		logger:                logger,
+		apiClient:             client,
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Unfortunately a bug was introduced in https://github.com/honeycombio/honeycomb-kubernetes-agent/pull/200. There is a nil pointer dereference due to a missing `apiClient` on runnable. 

## Short description of the changes

- Adding `apiClient` when runnable is initialized resolves the error and results in node labels being added to metric events, as confirmed by following local development steps to run the agent locally. 
