### PR TITLE
Unify logging, fix log verbosity

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -6,4 +6,4 @@ builds:
   - id: honeycomb-kubernetes-agent
     main: .
     ldflags:
-      - -X honeycomb-kubernetes-agent/version.VERSION={{.Env.VERSION}}
+      - -X github.com/honeycombio/honeycomb-kubernetes-agent/version.VERSION={{.Env.VERSION}}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -114,6 +114,6 @@ func (h *LineHandlerImpl) Handle(rawLine string) {
 			return
 		}
 	}
-	logrus.WithField("parsed", event).Debug("Sending line")
+	logrus.WithField("parsed", event).Trace("Sending line")
 	h.transmitter.Send(event)
 }

--- a/main.go
+++ b/main.go
@@ -230,9 +230,7 @@ func startMetricsService(config *config.MetricsConfig) error {
 			builder.AddField(k, v)
 		}
 
-		logger := logrus.StandardLogger()
-
-		svc, err := service.NewMetricsService(config, builder, logger, kubeClient)
+		svc, err := service.NewMetricsService(config, builder, kubeClient)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -42,16 +42,11 @@ type CmdLineOptions struct {
 	Validate   bool   `long:"validate" description:"Validate configuration and exit"`
 }
 
-var (
-	VERSION string
-)
-
 func init() {
 	// set the version string to our desired format
 	// version.VERSION is the importPath.name ld flag specified by build.sh
 	if version.VERSION == "" {
 		version.VERSION = "dev"
-
 	}
 	// init libhoney user agent properly
 	libhoney.UserAgentAddition = fmt.Sprintf("kubernetes/" + version.VERSION)
@@ -81,8 +76,14 @@ func main() {
 		logrus.Info("Configured split logging. trace, debug, info, and warn levels will now go to stdout")
 	}
 
-	if cfg.Verbosity == "debug" {
-		logrus.SetLevel(logrus.DebugLevel)
+	if cfg.Verbosity != "" {
+		level, err := logrus.ParseLevel(cfg.Verbosity)
+		if err == nil {
+			logrus.WithFields(logrus.Fields{
+				"newLevel": level.String(),
+			}).Info("Setting log verbosity")
+			logrus.SetLevel(level)
+		}
 	}
 
 	// Read write key from environment if not specified in config file.

--- a/metrics/accumulator.go
+++ b/metrics/accumulator.go
@@ -30,13 +30,12 @@ type MetricDataAccumulator struct {
 	metadata              *Metadata
 	metricGroupsToCollect map[MetricGroup]bool
 	time                  time.Time
-	logger                *logrus.Logger
 }
 
 func (a *MetricDataAccumulator) nodeStats(nodeResource *Resource, s stats.NodeStats) {
-	a.logger.WithFields(logrus.Fields{
+	logrus.WithFields(logrus.Fields{
 		"name": nodeResource.Name,
-	}).Debug("nodeStats")
+	}).Trace("nodeStats")
 
 	if !a.metricGroupsToCollect[NodeMetricGroup] {
 		return
@@ -53,9 +52,9 @@ func (a *MetricDataAccumulator) nodeStats(nodeResource *Resource, s stats.NodeSt
 }
 
 func (a *MetricDataAccumulator) podStats(podResource *Resource, s stats.PodStats) {
-	a.logger.WithFields(logrus.Fields{
+	logrus.WithFields(logrus.Fields{
 		"name": podResource.Name,
-	}).Debug("podStats")
+	}).Trace("podStats")
 
 	if !a.metricGroupsToCollect[PodMetricGroup] {
 		return
@@ -72,10 +71,10 @@ func (a *MetricDataAccumulator) podStats(podResource *Resource, s stats.PodStats
 }
 
 func (a *MetricDataAccumulator) containerStats(podResource *Resource, s stats.ContainerStats) {
-	a.logger.WithFields(logrus.Fields{
+	logrus.WithFields(logrus.Fields{
 		"podName": podResource.Name,
 		"name":    s.Name,
-	}).Debug("containerStats")
+	}).Trace("containerStats")
 
 	if !a.metricGroupsToCollect[ContainerMetricGroup] {
 		return
@@ -88,7 +87,7 @@ func (a *MetricDataAccumulator) containerStats(podResource *Resource, s stats.Co
 	resource, err := getContainerResource(podResource, s)
 
 	if err != nil {
-		a.logger.WithFields(logrus.Fields{
+		logrus.WithFields(logrus.Fields{
 			"pod":       podResource.Labels[LabelPodName],
 			"container": podResource.Labels[LabelContainerName],
 		}).Warn("failed to fetch container metrics")
@@ -105,10 +104,10 @@ func (a *MetricDataAccumulator) containerStats(podResource *Resource, s stats.Co
 }
 
 func (a *MetricDataAccumulator) volumeStats(podResource *Resource, s stats.VolumeStats) {
-	a.logger.WithFields(logrus.Fields{
+	logrus.WithFields(logrus.Fields{
 		"podName": podResource.Name,
 		"name":    s.Name,
-	}).Debug("volumeStats")
+	}).Trace("volumeStats")
 
 	if !a.metricGroupsToCollect[VolumeMetricGroup] {
 		return

--- a/metrics/metadata.go
+++ b/metrics/metadata.go
@@ -16,16 +16,14 @@ type Metadata struct {
 	NodesMetadata     *v1.NodeList
 	OmitLabels        []OmitLabel
 	IncludeNodeLabels bool
-	logger            *logrus.Logger
 }
 
-func NewMetadata(podsMetadata *v1.PodList, nodesMetadata *v1.NodeList, omitLabels []OmitLabel, includeNodeLabels bool, logger *logrus.Logger) *Metadata {
+func NewMetadata(podsMetadata *v1.PodList, nodesMetadata *v1.NodeList, omitLabels []OmitLabel, includeNodeLabels bool) *Metadata {
 	return &Metadata{
 		PodsMetadata:      podsMetadata,
 		NodesMetadata:     nodesMetadata,
 		OmitLabels:        omitLabels,
 		IncludeNodeLabels: includeNodeLabels,
-		logger:            logger,
 	}
 }
 
@@ -36,7 +34,7 @@ func (m *Metadata) GetNodeMetadataByName(name string) (*NodeMetadata, error) {
 		}
 	}
 
-	m.logger.WithFields(logrus.Fields{
+	logrus.WithFields(logrus.Fields{
 		"nodeName": name,
 	}).Error("Metadata: Node not found")
 	return &NodeMetadata{}, errors.New("node not found")
@@ -49,7 +47,7 @@ func (m *Metadata) GetPodMetadataByUid(uid types.UID) (*PodMetadata, error) {
 		}
 	}
 
-	m.logger.WithFields(logrus.Fields{
+	logrus.WithFields(logrus.Fields{
 		"podUid": uid,
 	}).Error("Metadata: Pod not found")
 	return &PodMetadata{}, errors.New("pod not found")
@@ -173,7 +171,7 @@ func (p *PodMetadata) GetStatusForContainer(name string) map[string]interface{} 
 		}
 	}
 	if s.ContainerID == "" {
-		p.Metadata.logger.WithFields(logrus.Fields{
+		logrus.WithFields(logrus.Fields{
 			"podName":       p.Pod.Name,
 			"containerName": name,
 		}).Error("Metadata: Container not found")

--- a/metrics/processor.go
+++ b/metrics/processor.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"github.com/sirupsen/logrus"
-
 	"time"
 
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
@@ -10,15 +8,13 @@ import (
 
 type Processor struct {
 	counterCache *Cache
-	logger       *logrus.Logger
 }
 
-func NewMetricsProcessor(fetchInterval time.Duration, logger *logrus.Logger) *Processor {
+func NewMetricsProcessor(fetchInterval time.Duration) *Processor {
 	timeout := fetchInterval * (5 + 1)
 	cache := NewCache(timeout)
 	return &Processor{
 		counterCache: cache,
-		logger:       logger,
 	}
 
 }
@@ -30,7 +26,6 @@ func (p *Processor) GenerateMetricsData(summary *stats.Summary, metadata *Metada
 		metricGroupsToCollect: metricGroupsToCollect,
 		mp:                    p,
 		time:                  time.Now(),
-		logger:                p.logger,
 	}
 
 	nodeResource := getNodeResource(summary.Node, metadata)


### PR DESCRIPTION
- Simplifies and standardizes logging across the entire agent. Everything uses the static logrus logger, instead of creating multiple instances.
- Will now properly respect `verbosity` config setting 
- also fixes setting `version.VERSION` in build flags
- reclassifies some debug log statements as trace level

This is the first PR as a prelude to fix retry logic. While trying to fix it, I realized logging was inconsistent and not at the levels I would configure for the agent. The vast majority of the changes here are mundane changes to reference the static `logrus` logger instead of an instance once passed in. Going this route ensures we can set all logging settings on startup and everything will respect it.

