### PR TITLE
fix: check for existence of optional MemoryStats to prevent exceptions

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -228,6 +228,20 @@ func TestMemMetrics(t *testing.T) {
 	assert.Equal(t, float64(23191552), metrics[MeasureMemoryRSS].GetValue(), "Memory RSS")
 }
 
+func TestMemMetricsOptional(t *testing.T) {
+	summary, _ := createMockSourceAssets(true, false, nil, false)
+
+	p := NewMetricsProcessor(10*time.Second, logrus.StandardLogger())
+
+	metrics := p.MemMetrics(summary.Pods[1].Memory, 0)
+
+	require.Equal(t, 0, len(metrics))
+
+	assert.Empty(t, metrics[MeasureMemoryUsage])
+	assert.Empty(t, metrics[MeasureMemoryUtilization])
+	assert.Empty(t, metrics[MeasureMemoryRSS])
+}
+
 func TestNetworkMetrics(t *testing.T) {
 	summary, _ := createMockSourceAssets(true, false, nil, false)
 

--- a/metrics/processor.go
+++ b/metrics/processor.go
@@ -146,6 +146,10 @@ func (p *Processor) CpuMetrics(s *stats.CPUStats, limit float64) Metrics {
 }
 
 func (p *Processor) MemMetrics(s *stats.MemoryStats, limit float64) Metrics {
+	// MemoryStats are optional
+	if s == nil {
+		return Metrics{}
+	}
 	// if resource limits defined get utilization
 	var utilization float64
 	if limit > 0 {

--- a/testdata/stats-summary.json
+++ b/testdata/stats-summary.json
@@ -351,14 +351,7 @@
    "test-empty-cpu": {
     "time": "2020-09-16T03:30:56Z"
    },
-   "memory": {
-    "time": "2020-09-16T03:30:56Z",
-    "usageBytes": 9392128,
-    "workingSetBytes": 4403200,
-    "rssBytes": 2867200,
-    "pageFaults": 0,
-    "majorPageFaults": 0
-   },
+   "test-empty-memory": {},
    "network": {
     "time": "2020-09-16T03:30:54Z",
     "name": "eth0",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #228 

## Short description of the changes

- MemoryStats are optional, and omitted if empty. This change returns an empty Metrics{} if MemoryStats are empty.
