### PR TITLE
Remove memory.utilization memory counter

### DIFF
--- a/metrics/conventions.go
+++ b/metrics/conventions.go
@@ -24,7 +24,6 @@ const (
 	MeasureCpuUtilization        = "cpu.utilization"
 	MeasureMemoryAvailable       = "memory.available"
 	MeasureMemoryUsage           = "memory.usage"
-	MeasureMemoryUtilization     = "memory.utilization"
 	MeasureMemoryRSS             = "memory.rss"
 	MeasureMemoryWorkingSet      = "memory.working_set"
 	MeasureMemoryPageFaults      = "memory.page_faults"

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -222,7 +222,6 @@ func TestMemMetrics(t *testing.T) {
 	require.Equal(t, 7, len(metrics))
 
 	assert.Equal(t, float64(2143281152), metrics[MeasureMemoryUsage].GetValue(), "Memory Usage")
-	assert.InDelta(t, 0.000001, 99.804300603, metrics[MeasureMemoryUtilization].GetValue(), "Memory Utilization")
 	assert.Equal(t, float64(23191552), metrics[MeasureMemoryRSS].GetValue(), "Memory RSS")
 }
 
@@ -236,7 +235,6 @@ func TestMemMetricsOptional(t *testing.T) {
 	require.Equal(t, 0, len(metrics))
 
 	assert.Empty(t, metrics[MeasureMemoryUsage])
-	assert.Empty(t, metrics[MeasureMemoryUtilization])
 	assert.Empty(t, metrics[MeasureMemoryRSS])
 }
 

--- a/metrics/processor.go
+++ b/metrics/processor.go
@@ -145,19 +145,10 @@ func (p *Processor) MemMetrics(s *stats.MemoryStats, limit float64) Metrics {
 	if s == nil {
 		return Metrics{}
 	}
-	// if resource limits defined get utilization
-	var utilization float64
-	if limit > 0 {
-		if s.UsageBytes != nil {
-			usage := float64(*s.UsageBytes)
-			utilization = (usage / limit) * 100
-		}
-	}
 
 	return Metrics{
 		MeasureMemoryAvailable:       &Metric{Type: MetricTypeInt, IntValue: s.AvailableBytes},
 		MeasureMemoryUsage:           &Metric{Type: MetricTypeInt, IntValue: s.UsageBytes},
-		MeasureMemoryUtilization:     &Metric{Type: MetricTypeFloat, FloatValue: &utilization},
 		MeasureMemoryRSS:             &Metric{Type: MetricTypeInt, IntValue: s.RSSBytes},
 		MeasureMemoryWorkingSet:      &Metric{Type: MetricTypeInt, IntValue: s.WorkingSetBytes},
 		MeasureMemoryPageFaults:      &Metric{Type: MetricTypeInt, IntValue: s.PageFaults},


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Removes the memory.utilization memory counter as it's inaccurate (see #215).`memory.working_set` is closer to the expected calculation and is already reported by by the agent.

- Closes #215

## Short description of the changes
- Removes the `memory.utilization` measurement, including tests