### PR TITLE
remove Pierre from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/telemetry-team @puckpuck @lizthegrey @paulosman
+* @honeycombio/telemetry-team @lizthegrey @paulosman


### PR DESCRIPTION
@puckpuck asked to be removed from CODEOWNERS to reduce the volume of GitHub notifications he gets.

![make it stop!](https://user-images.githubusercontent.com/517302/169545356-6ab56b68-6394-4a6d-a7a5-2e56e90ea24d.gif)

I apologize that this particular request will be sending him yet another notification. But also, we really ought to give him the chance to put his thumb on it. 😀 