### PR TITLE
Deflake flaky tests

### DIFF
--- a/tailer/state.go
+++ b/tailer/state.go
@@ -21,7 +21,7 @@ type StateRecorderImpl struct {
 }
 
 func NewStateRecorder(stateFilePath string) (StateRecorder, error) {
-	db, err := bolt.Open(stateFilePath, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	db, err := bolt.Open(stateFilePath, 0600, &bolt.Options{Timeout: 2 * time.Second})
 	if err != nil {
 		return nil, err
 	}

--- a/tailer/tailer_test.go
+++ b/tailer/tailer_test.go
@@ -138,18 +138,18 @@ func TestPathWatching(t *testing.T) {
 	}
 
 	// The PathWatcher only checks once a second, so we should sleep for slightly longer than that.
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2000 * time.Millisecond)
 
 	for _, l := range loggers {
 		l.Rotate()
 		l.Write()
 	}
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2000 * time.Millisecond)
 
 	for _, l := range loggers {
 		l.Rotate()
 	}
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2000 * time.Millisecond)
 	watcher.Stop()
 
 	assert.Equal(t, 2, len(handlerFactory.handlers))

--- a/tailer/tailer_test.go
+++ b/tailer/tailer_test.go
@@ -137,18 +137,19 @@ func TestPathWatching(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	time.Sleep(time.Second)
+	// The PathWatcher only checks once a second, so we should sleep for slightly longer than that.
+	time.Sleep(1500 * time.Millisecond)
 
 	for _, l := range loggers {
 		l.Rotate()
 		l.Write()
 	}
-	time.Sleep(time.Second)
+	time.Sleep(1500 * time.Millisecond)
 
 	for _, l := range loggers {
 		l.Rotate()
 	}
-	time.Sleep(time.Second)
+	time.Sleep(1500 * time.Millisecond)
 	watcher.Stop()
 
 	assert.Equal(t, 2, len(handlerFactory.handlers))


### PR DESCRIPTION
## Which problem is this PR solving?

The polling strategy of the podtailer has a re-poll time of 1 second; the best guess I had for the flaky tests only in CI was that on a CPU-limited CI system, the 1-second sleep in the test was too fast for the 1-second retry time of the podtailer. On the laptop with many cores, there's plenty of CPU around to run the tailers in a separate thread. 

This matters for this test because it's rotating logs and then closing them quickly; under normal circumstances (even under small CPU allocations), the tailer should have plenty of time to catch up to a rotated log.

## Short description of the changes

- Lengthen the sleep time in the flaky test
- Lengthen the wait time for Bolt to acquire a file lock

Fixes #263 
Fixes #225