### PR TITLE
maint: update action to auto-create issue for helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Create an issue
         uses: actions-ecosystem/action-create-issue@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           repo: github.com/honeycombio/helm-charts
           title: ${{ steps.date.outputs.today }}
           body: |


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- In #255 we added a workflow to auto-create an issue for the helm chart repo, but the [job failure ](https://github.com/honeycombio/honeycomb-kubernetes-agent/actions/runs/2468983242)shows that it needs to be `github_token` instead of `github-token` (with an underscore not hyphen).

## Short description of the changes

- use `github_token` instead of `github-token` in `release.yml` github workflow
