### PR TITLE
Combine metrics from duplicate pods

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -52,6 +52,7 @@ func createMockAccumulator(metadata *Metadata, mg map[MetricGroup]bool) *MetricD
 		metricGroupsToCollect: mg,
 		mp:                    p,
 		time:                  time.Now(),
+		Data:                  make(map[string]*ResourceMetrics),
 	}
 }
 
@@ -340,7 +341,7 @@ func TestNodeStats(t *testing.T) {
 	node := getNodeResource(summary.Node, metadata)
 
 	acc.nodeStats(node, summary.Node)
-	data := acc.Data[0]
+	data := acc.Data[node.Name]
 	assert.Equal(t, "duckboat-01", data.Resource.Name)
 	assert.Equal(t, 0, len(data.Resource.Status))
 	assert.Equal(t, 9, len(data.Resource.Labels))
@@ -355,7 +356,7 @@ func TestNodeStats(t *testing.T) {
 	node = getNodeResource(summary.Node, metadata)
 
 	acc.nodeStats(node, summary.Node)
-	data = acc.Data[0]
+	data = acc.Data[node.Name]
 	assert.Equal(t, "duckboat-01", data.Resource.Name)
 	assert.Equal(t, 1, len(data.Resource.Labels))
 }
@@ -369,7 +370,7 @@ func TestPodStats(t *testing.T) {
 	pod := getPodResource(node, podStats, metadata)
 
 	acc.podStats(pod, podStats)
-	data := acc.Data[0]
+	data := acc.Data[pod.Name]
 
 	assert.Equal(t, "speaker-cpxhz", data.Resource.Name)
 	assert.Equal(t, 4, len(data.Resource.Status))
@@ -391,7 +392,7 @@ func TestContainerStats(t *testing.T) {
 	pod := getPodResource(node, podStats, metadata)
 
 	acc.containerStats(pod, podStats.Containers[0])
-	data := acc.Data[0]
+	data := acc.Data[pod.Name]
 
 	assert.Equal(t, "speaker", data.Resource.Name)
 	assert.Equal(t, 4, len(data.Resource.Status))
@@ -414,7 +415,7 @@ func TestVolumeStats(t *testing.T) {
 	pod := getPodResource(node, podStats, metadata)
 
 	acc.volumeStats(pod, podStats.VolumeStats[0])
-	data := acc.Data[0]
+	data := acc.Data[pod.Name]
 
 	assert.Equal(t, "speaker-token-kpzds", data.Resource.Name)
 	assert.Equal(t, 0, len(data.Resource.Status))

--- a/metrics/processor.go
+++ b/metrics/processor.go
@@ -26,6 +26,7 @@ func (p *Processor) GenerateMetricsData(summary *stats.Summary, metadata *Metada
 		metricGroupsToCollect: metricGroupsToCollect,
 		mp:                    p,
 		time:                  time.Now(),
+		Data:                  make(map[string]*ResourceMetrics),
 	}
 
 	nodeResource := getNodeResource(summary.Node, metadata)
@@ -47,7 +48,12 @@ func (p *Processor) GenerateMetricsData(summary *stats.Summary, metadata *Metada
 		}
 	}
 
-	return acc.Data
+	// return flat array of metrics
+	metrics := make([]*ResourceMetrics, len(acc.Data))
+	for _, metric := range acc.Data {
+		metrics = append(metrics, metric)
+	}
+	return metrics
 }
 
 func (p *Processor) GetCounterDelta(res *Resource, name string, newMetric *Metric) float64 {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Occasionally, the same pod will returned multiple times which leads to duplicate events being created when creating metrics.

This PR accumulates metrics per pod name, then returns a single result.

- Fixes #278 

## Short description of the changes
- Update accumulator result type to be a `map[string][]*ResourceMetrics` using the pod name as the key
- Update metrics accumulator to re-use an existing entry in the map if it exists
- Update tests to use pod name instead of integer accessor

NOTE: The following tests are currently failing:
- TestGenerateMetricsData
- TestCounterMetrics