### PR TITLE
Put the k8s metadata processor first

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -63,8 +63,14 @@ func NewLineHandlerFactoryFromConfig(
 		}
 		ret.processors = append(ret.processors, processor)
 	}
-	ret.processors = append(ret.processors, extraProcessors...)
-
+	for _, ep := range extraProcessors {
+		if _, ok := ep.(*processors.KubernetesMetadataProcessor); ok {
+			// put the K8s metadata processor first in line (see #296)
+			ret.processors = append([]processors.Processor{ep}, ret.processors...)
+		} else {
+			ret.processors = append(ret.processors, ep)
+		}
+	}
 	return ret, nil
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Processors in the k8s agent might want to work on fields injected by the k8s processor, but the implementation put that processor at the end of the list. 

## Short description of the changes

- Put the k8s processor at the beginning of the processor list.

## Notes

Because the k8s metadata processor is not optional and has no configuration, there was no easy way to make it an optional feature to move it in the processing order. There's a slight possibility that this change could cause an existing configuration to deliver different results, but I believe that the only chance of that happening is in a configuration where the k8s metadata processor was overwriting fields that were modified by another processor. That doesn't seem like a useful configuration for anyone so I don't think this needs a "breaking" change warning (and in fact, #296 calls it a bug).

@puckpuck and @mterhar I would appreciate your review on this one.

Fixes #296.

