### PR TITLE
Add support for building sample keys from integer fields

### DIFF
--- a/processors/sample.go
+++ b/processors/sample.go
@@ -88,10 +88,11 @@ func makeDynSampleKey(ev *event.Event, keys []string) string {
 			switch val := val.(type) {
 			case bool:
 				key[i] = strconv.FormatBool(val)
+			case int:
+				key[i] = strconv.Itoa(val)
 			case int64:
 				key[i] = strconv.FormatInt(val, 10)
 			case float64:
-
 				key[i] = strconv.FormatFloat(val, 'E', -1, 64)
 			case string:
 				key[i] = val

--- a/processors/sample_test.go
+++ b/processors/sample_test.go
@@ -1,0 +1,17 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSamplerCanBuildsKeysWithInts(t *testing.T) {
+	key := makeDynSampleKey(&event.Event{
+		Data: map[string]interface{}{
+			"status": "200",
+		},
+	}, []string { "status"})
+	assert.Equal(t, "200", key)
+}

--- a/processors/sample_test.go
+++ b/processors/sample_test.go
@@ -10,7 +10,7 @@ import (
 func TestSamplerCanBuildsKeysWithInts(t *testing.T) {
 	key := makeDynSampleKey(&event.Event{
 		Data: map[string]interface{}{
-			"status": "200",
+			"status": 200,
 		},
 	}, []string { "status"})
 	assert.Equal(t, "200", key)


### PR DESCRIPTION
## Which problem is this PR solving?
If an dynamic sampler is configured to user an event field that is an int, not int64, the field is ignored. This can lead to inconsistent dynamic keys being used.

In the case only integer fields are used, eg a status field, it would result in an key `""`.

## Short description of the changes
- Add support for int field types when building an event key to use with the dynamic sampler
- Add unit test to
