### PR TITLE
Add MinEventsPerSec to config

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -127,8 +127,7 @@ type | `"static"` or `"dynamic"` | How events should be sampled.
 rate | integer | The rate at which to sample events. Specifying a sample rate of 20 will cause one in 20 events to be sent.
 keys | list of strings | The list of field keys to use when doing dynamic sampling.
 windowSize | int | How often to refresh estimated sample rates when doing dynamic sampling, in seconds. Defaults to 30 seconds.
-minEventsPerSec | int | Whenever the number of events per second being processed falls below this value for a time window (see windowSize), sampling will be disabled for the next time window (all events will be sent with a sample rate of 1). Default value is set by the sampling library to 50,
-and setting minEventsPerSec to 0 will use the default. To set the minimum possible value, use 1.
+minEventsPerSec | int | Whenever the number of events per second being processed falls below this value for a time window (see windowSize), sampling will be disabled for the next time window (all events will be sent with a sample rate of 1). Default value is set by the sampling library to 50, and setting minEventsPerSec to 0 will use the default. To set the minimum possible value, use 1.
 
 ### drop_field
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -127,6 +127,7 @@ type | `"static"` or `"dynamic"` | How events should be sampled.
 rate | integer | The rate at which to sample events. Specifying a sample rate of 20 will cause one in 20 events to be sent.
 keys | list of strings | The list of field keys to use when doing dynamic sampling.
 windowSize | int | How often to refresh estimated sample rates when doing dynamic sampling, in seconds. Defaults to 30 seconds.
+minEventsPerSec | int | Whenever the number of events per second being processed falls below this value for a time window (see windowSize), sampling will be disabled for the next time window (all events will be sent with a sample rate of 1).
 
 ### drop_field
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -127,7 +127,8 @@ type | `"static"` or `"dynamic"` | How events should be sampled.
 rate | integer | The rate at which to sample events. Specifying a sample rate of 20 will cause one in 20 events to be sent.
 keys | list of strings | The list of field keys to use when doing dynamic sampling.
 windowSize | int | How often to refresh estimated sample rates when doing dynamic sampling, in seconds. Defaults to 30 seconds.
-minEventsPerSec | int | Whenever the number of events per second being processed falls below this value for a time window (see windowSize), sampling will be disabled for the next time window (all events will be sent with a sample rate of 1).
+minEventsPerSec | int | Whenever the number of events per second being processed falls below this value for a time window (see windowSize), sampling will be disabled for the next time window (all events will be sent with a sample rate of 1). Default value is set by the sampling library to 50,
+and setting minEventsPerSec to 0 will use the default. To set the minimum possible value, use 1.
 
 ### drop_field
 

--- a/processors/sample.go
+++ b/processors/sample.go
@@ -25,10 +25,11 @@ type Sampler struct {
 }
 
 type samplerConfig struct {
-	Type       SampleType
-	Rate       uint
-	Keys       []string
-	WindowSize int
+	Type            SampleType
+	Rate            uint
+	Keys            []string
+	WindowSize      int
+	MinEventsPerSec int
 }
 
 func (s *Sampler) Init(options map[string]interface{}) error {
@@ -48,6 +49,8 @@ func (s *Sampler) Init(options map[string]interface{}) error {
 		// Default to 30 seconds if not otherwise specified
 		config.WindowSize = 30
 	}
+	// MinEventsPerSec is defaulted to 50 by the sampler itself, if the value
+	// specified in our config is 0 or missing.
 
 	s.config = config
 
@@ -55,9 +58,10 @@ func (s *Sampler) Init(options map[string]interface{}) error {
 		s.dynsampler = &dynsampler.AvgSampleWithMin{
 			GoalSampleRate:    int(config.Rate),
 			ClearFrequencySec: config.WindowSize,
+			MinEventsPerSec:   config.MinEventsPerSec,
 		}
 		if err := s.dynsampler.Start(); err != nil {
-			return fmt.Errorf("Error starting dynamic sampler: %v", err)
+			return fmt.Errorf("error starting dynamic sampler: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Which problem is this PR solving?

- Allows configuration of the dynsampler config item MinEventsPerSecond
- Fixes #307

Addresses a live customer problem.

## Short description of the changes

- Adds a new configuration value and passes it to the sampler
- Documents its existence
