### PR TITLE
maint: Add labels to build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -29,5 +29,8 @@ ko publish \
   --tags "head,${VERSION}" \
   --base-import-paths \
   --platform "${PLATFORM}" \
+  --image-label org.opencontainers.image.source=https://github.com/honeycombio/honeycomb-kubernetes-agent \
+  --image-label org.opencontainers.image.licenses=Apache-2.0 \
+  --image-label org.opencontainers.image.revision=${CIRCLE_SHA1} \
   ${PUBLISH_ARGS-} \
   .


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Adds labels to the built images

## Short description of the changes

- adds 3 new labels to the built images

Tested with personal credentials pushing to https://hub.docker.com/r/thelmuth34/honeycomb-kubernetes-agent/tags. Outcome of the labels from a `docker inspect` command looked like:

```
            "Labels": {
                "org.opencontainers.image.licenses": "Apache-2.0",
                "org.opencontainers.image.revision": "d721c5f1f30254d8f3a0658bf071675d59ccaa79",
                "org.opencontainers.image.source": "https://github.com/honeycombio/honeycomb-kubernetes-agent"
            }
```
