### PR TITLE
maint: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/collection-team"
       - "lizthegrey"
     commit-message:
       prefix: "maint"


### PR DESCRIPTION
notify collection team instead of telemetry