### PR TITLE
fix(k8sagent): retry watcher if it stops; fixes #416

### DIFF
--- a/k8sagent/watcher.go
+++ b/k8sagent/watcher.go
@@ -157,17 +157,26 @@ func runInformer(
 
 	watchlist := &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 	resyncPeriod := time.Minute
-	_, controller := cache.NewInformer(
-		watchlist,
-		&v1.Pod{},
-		resyncPeriod,
-		handler,
-	)
+	go func() {
+		for {
+			_, controller := cache.NewInformer(
+				watchlist,
+				&v1.Pod{},
+				resyncPeriod,
+				handler,
+			)
 
-	logrus.WithFields(logrus.Fields{
-		"labelSelector": labelSelector,
-		"namespace":     namespace,
-		"fieldSelector": fieldSelector,
-	}).Debug("Starting informer")
-	go controller.Run(wait.NeverStop)
+			logrus.WithFields(logrus.Fields{
+				"labelSelector": labelSelector,
+				"namespace":     namespace,
+				"fieldSelector": fieldSelector,
+			}).Debug("Starting informer")
+			controller.Run(wait.NeverStop)
+			logrus.WithFields(logrus.Fields{
+				"labelSelector": labelSelector,
+				"namespace":     namespace,
+				"fieldSelector": fieldSelector,
+			}).Warning("Informer unexpectedly stopped")
+		}
+	}()
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- In #416 I noted that the apiserver dying can silently result in polling falling behind

## Short description of the changes

- Retries polling if the watcher fails.