### PR TITLE
ci: move publishing image to separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,26 @@
 # Use the latest 2.1 version of CircleCI pipeline processing engine, see https://circleci.com/docs/2.0/configuration-reference/
 version: 2.1
 
-# required as all of the jobs need to have a tag filter for some reason
-tag_filters: &tag_filters
+filters_always: &filters_always
   filters:
-      tags:
-        only: /.*/
+    tags:
+      only: /.*/
+
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
+executors:
+  docker-go:
+    docker:
+      - image: cimg/go:1.22
 
 jobs:
   build_agent:
-    docker:
-      - image: cimg/go:1.22
-    # needed to build docker images, attach mount points, etc
+    executor: docker-go
     steps:
       - setup_remote_docker
       - checkout
@@ -21,15 +30,21 @@ jobs:
       - run: ./build/build.sh
       - run: ./build/test.sh .
       - run: e2e-tests/test.sh
+
+  publish_dockerhub:
+    executor: docker-go
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run: go install github.com/google/ko@latest
+      - run: echo "VERSION=$(cat version.txt | tr -d '\n')" >> $BASH_ENV
       - run:
-          name: "Deploy on tagged master push"
+          name: "publish image to Docker Hub"
+          environment:
+            KO_DOCKER_REPO: honeycombio
           command: |
-            if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -z "${CIRCLE_BRANCH}" ] && [ -n "${CIRCLE_TAG}" ]; then
-              echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
-              KO_DOCKER_REPO=honeycombio ./build/build.sh
-            else
-              echo "skipping push. CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}, CIRCLE_BRANCH=${CIRCLE_BRANCH}, CIRCLE_TAG=${CIRCLE_TAG}"
-            fi;
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+            ./build/build.sh
 
   publish_github:
     docker:
@@ -43,18 +58,19 @@ jobs:
             echo "about to publish to tag ${CIRCLE_TAG}"
             ghr --draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
 
-# Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
 workflows:
   version: 2
   build:
     jobs:
-      - build_agent: *tag_filters
-      - publish_github:
+      - build_agent:
+          <<: *filters_always
+      - publish_dockerhub:
+          <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - build_agent
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+      - publish_github:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_agent


### PR DESCRIPTION
## Which problem is this PR solving?

- Publishing the image to Docker Hub requires secrets, so provide them properly.

## Short description of the changes

- Publishing to Docker Hub moved to a new job.
  - Separates the act of publishing the image to Docker Hub (requires secrets) from the act of building and testing (does not require secrets).
- In the new job, the command to publish is much simplified now that the job can be gated to run only on version-tagged commits.
- Secrets needed to publish are provided through CircleCI Context as recommended by Circle.
- reused filter definitions common in our other CI configs
- declared the version of Go to build with in a single named executor