### PR TITLE
fix: all messages to console are now structured logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,11 +59,11 @@ func init() {
 func main() {
 	flags, err := parseFlags()
 	if err != nil {
-		fmt.Printf("Error parsing options:\n%v\n", err)
+		logrus.WithError(err).Error("Error parsing options")
 	}
 	cfg, err := config.ReadFromFile(flags.ConfigPath)
 	if err != nil {
-		fmt.Printf("Error reading configuration:\n%v\n", err)
+		logrus.WithError(err).Fatal("Error reading configuration")
 		os.Exit(1)
 	}
 
@@ -142,7 +142,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("running")
+	logrus.Info("running")
 	waitForSignal()
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Output to console without structure gives parsers indigestion. No plain `fmt.Print`ing in the runtime!

## Short description of the changes

- Replace `fmt.Print*` calls in the non-test code with appropriate `logrus` functions to structure the output.
