### PR TITLE
feat: allow a per-watcher apiKey

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 
 type WatcherConfig struct {
 	Parser    *ParserConfig
+	APIKey    string `yaml:"apiKey"`
 	Dataset   string
 	Namespace string
 	// Distinguish between nil and empty string in the LabelSelector

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -25,6 +25,7 @@ to handle in a specific way, and has the following keys:
 | paths         | †         | []string | A list of paths to watch. Allows for glob matching, including `**`. Mutually exclusive with labelSelector.  Should only be used if labelSelector does not suite your needs |
 | parser        | yes       | string   | Describes how this watcher should parse events.                                                                                                                            |
 | dataset       | yes       | string   | The dataset that this watcher should send events to.                                                                                                                       |
+| apiKey        | no        | string   | Send this watcher's events with a different API key than the top-level one, selecting a different Honeycomb environment. Defaults to the top-level `apiKey`.                |
 | containerName | no        | string   | If you only want to consume logs from one container in a multi-container pod, the name of the container to watch.                                                          |
 | processors    | no        | list     | A list of [processors](#processors) to apply to events after they're parsed                                                                                                |
 | exclude       | no        | []string | A list of paths to exclude from the watch. Only used when `labelSelector` is configured. Allows for glob matching, including `**`.                                         |

--- a/event/event.go
+++ b/event/event.go
@@ -3,6 +3,7 @@ package event
 import "time"
 
 type Event struct {
+	APIKey     string
 	Dataset    string
 	Path       string
 	SampleRate uint

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -111,6 +111,7 @@ func (h *LineHandlerImpl) Handle(rawLine string) {
 		// TODO: is there a better way to handle this?
 		return
 	}
+	event.APIKey = h.config.APIKey
 	event.Dataset = h.config.Dataset
 	event.Path = h.path
 	for _, p := range h.processors {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -96,6 +96,42 @@ func TestInvalidConfigurations(t *testing.T) {
 	}
 }
 
+func TestPerWatcherAPIKey(t *testing.T) {
+	testCases := []*testCase{
+		{
+			config:        `{"dataset": "kubernetestest", "apiKey": "watcher-key", "parser": "json"}`,
+			unwrapperType: raw,
+			lines:         []string{`{"field": "value"}`},
+			output: []event.Event{
+				{
+					Data:       map[string]interface{}{"field": "value"},
+					APIKey:     "watcher-key",
+					Dataset:    "kubernetestest",
+					Path:       "/tmp/testpath",
+					RawMessage: `{"field": "value"}`,
+				},
+			},
+		},
+		{
+			config:        `{"dataset": "kubernetestest", "parser": "json"}`,
+			unwrapperType: raw,
+			lines:         []string{`{"field": "value"}`},
+			output: []event.Event{
+				{
+					Data:       map[string]interface{}{"field": "value"},
+					Dataset:    "kubernetestest",
+					Path:       "/tmp/testpath",
+					RawMessage: `{"field": "value"}`,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.check(t)
+	}
+}
+
 func TestNginxParsing(t *testing.T) {
 	testCases := []*testCase{
 		{

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -27,6 +27,9 @@ type HoneycombTransmitter struct {
 func (ht *HoneycombTransmitter) Send(ev *event.Event) {
 
 	libhoneyEvent := libhoney.NewEvent()
+	if ev.APIKey != "" {
+		libhoneyEvent.WriteKey = ev.APIKey
+	}
 	libhoneyEvent.Dataset = ev.Dataset
 	if ev.SampleRate != 0 {
 		libhoneyEvent.SampleRate = ev.SampleRate


### PR DESCRIPTION
Refs #445

## Problem

`apiKey` is global, so one agent can only send to one Honeycomb environment. In Environments & Services the key selects the environment, so a cluster whose namespaces map to different environments cannot be covered by a single DaemonSet.

## Solution

Allow `apiKey` on a watcher. Empty inherits the top-level key, so existing configurations are unchanged. libhoney already treats `Event.WriteKey` as a per-event override, so the transmitter only needs to set it.

```yaml
apiKey: global-key
watchers:
  - labelSelector: "app=frontend"
    namespace: staging
    dataset: staging-logs
    apiKey: staging-environment-key
  - labelSelector: "app=frontend"
    namespace: production
    dataset: production-logs
    apiKey: production-environment-key
```
