### PR TITLE
feat: add a dataset_from_field processor

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -252,6 +252,29 @@ The above configuration would route events where `host` exists and is equal to
 `www.example.com` to the `www` dataset. All others would be routed to the
 default dataset for this watcher.
 
+### dataset_from_field
+
+The `dataset_from_field` processor sets the event's dataset from the value of a field. Unlike
+`route_event` it needs no list of values, so it suits an Environments & Services environment where
+each service has its own dataset and the log events already carry `service.name`.
+
+The event's dataset is left as the watcher configured it when the field is absent, empty, or not a
+string.
+
+**Options:**
+
+| key   | value  | description                                        |
+|-------|--------|----------------------------------------------------|
+| field | string | The name of the event field to take the dataset from |
+
+Example configuration
+
+```yaml
+processors:
+- dataset_from_field:
+    field: service.name
+```
+
 ### rename_field
 
 The `rename_field` processor will rename the specified field in all events, if it exists, before sending them to Honeycomb. You can use this to standardize field names across data sources, for example. Note that if the `new` field already exists, it will be overwritten with the value in the `original` field.

--- a/processors/dataset_from_field.go
+++ b/processors/dataset_from_field.go
@@ -1,0 +1,60 @@
+package processors
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrMissingFieldDatasetFromField = errors.New("dataset_from_field requires field to be set")
+)
+
+type DatasetResolver struct {
+	config *datasetResolverConfig
+}
+
+type datasetResolverConfig struct {
+	Field string
+}
+
+func (f *DatasetResolver) Init(options map[string]interface{}) error {
+	config := &datasetResolverConfig{}
+	err := mapstructure.Decode(options, config)
+	if err != nil {
+		return err
+	}
+
+	if config.Field == "" {
+		return ErrMissingFieldDatasetFromField
+	}
+	f.config = config
+	return nil
+}
+
+func (f *DatasetResolver) Process(ev *event.Event) bool {
+	if ev.Data == nil {
+		return true
+	}
+	val, ok := ev.Data[f.config.Field]
+	if !ok {
+		return true
+	}
+
+	valString, ok := val.(string)
+	if !ok {
+		logrus.WithFields(logrus.Fields{
+			"key":   f.config.Field,
+			"value": val,
+			"type":  fmt.Sprintf("%T", val)}).
+			Debug("Not setting dataset from field of non-string type")
+		return true
+	}
+	if valString != "" {
+		ev.Dataset = valString
+	}
+	return true
+}

--- a/processors/dataset_from_field_test.go
+++ b/processors/dataset_from_field_test.go
@@ -1,0 +1,56 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/honeycombio/honeycomb-kubernetes-agent/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatasetFromField(t *testing.T) {
+	var processor Processor
+	processor = &DatasetResolver{}
+
+	err := processor.Init(map[string]interface{}{"field": "service.name"})
+	assert.Equal(t, nil, err, "init should not error")
+
+	e := &event.Event{
+		Dataset: "fallback",
+		Data:    map[string]interface{}{"service.name": "fintech-connector"},
+	}
+	cont := processor.Process(e)
+	assert.Equal(t, true, cont, "Process should return true, to signal continued processing")
+	assert.Equal(t, "fintech-connector", e.Dataset, "dataset should come from the field")
+
+	cont = processor.Process(&event.Event{Data: map[string]interface{}{}})
+	assert.Equal(t, true, cont, "Process should return true, to signal continued processing")
+}
+
+func TestDatasetFromFieldLeavesDatasetAlone(t *testing.T) {
+	processor := &DatasetResolver{}
+	err := processor.Init(map[string]interface{}{"field": "service.name"})
+	assert.Equal(t, nil, err, "init should not error")
+
+	testCases := []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{"field absent", map[string]interface{}{"msg": "hi"}},
+		{"field empty", map[string]interface{}{"service.name": ""}},
+		{"field not a string", map[string]interface{}{"service.name": 42}},
+		{"no data", nil},
+	}
+
+	for _, tc := range testCases {
+		e := &event.Event{Dataset: "fallback", Data: tc.data}
+		cont := processor.Process(e)
+		assert.Equal(t, true, cont, tc.name+": Process should return true")
+		assert.Equal(t, "fallback", e.Dataset, tc.name+": dataset should be unchanged")
+	}
+}
+
+func TestDatasetFromFieldRequiresField(t *testing.T) {
+	processor := &DatasetResolver{}
+	err := processor.Init(map[string]interface{}{})
+	assert.Equal(t, ErrMissingFieldDatasetFromField, err, "init should require field")
+}

--- a/processors/processors.go
+++ b/processors/processors.go
@@ -47,6 +47,8 @@ func NewProcessor(name string, options map[string]interface{}) (Processor, error
 	switch name {
 	case "route_event":
 		p = &EventRouter{}
+	case "dataset_from_field":
+		p = &DatasetResolver{}
 	case "request_shape":
 		p = &RequestShaper{}
 	case "drop_field":


### PR DESCRIPTION
Refs #445

## Problem

In Environments & Services each service has its own dataset. `route_event` can map a field value to a dataset, but it requires every value to be listed, so it has to be edited whenever a service is added.

## Solution

Add a `dataset_from_field` processor that takes the dataset from the value of a field. The dataset is left as the watcher configured it when the field is absent, empty, or not a string.

```yaml
watchers:
  - labelSelector: "app=frontend"
    namespace: staging
    dataset: staging-logs
    parser: json
    processors:
      - dataset_from_field:
          field: service.name
```
