### PR TITLE
ci: base the e2e image on alpine/k8s

### DIFF
--- a/e2e-tests/internal/Dockerfile
+++ b/e2e-tests/internal/Dockerfile
@@ -1,8 +1,8 @@
-FROM bitnami/kubectl:1.18
+FROM alpine/k8s:1.21.13
 USER 0
-RUN install_packages jq netcat
+RUN apk add --no-cache netcat-openbsd
 RUN mkdir /.kube
-RUN chown 1001 .kube
+RUN chown 1001 /.kube
 USER 1001
 COPY ./test_internal.sh /
 COPY ./testspec.yaml /


### PR DESCRIPTION
Refs #445

## Problem

`e2e-tests/internal/Dockerfile` cannot build, so every build in the project is red at the `e2e-tests/test.sh` step. Two independent faults:

1. Bitnami withdrew the versioned tags from `docker.io/bitnami/kubectl`, which now publishes only `latest`, so `bitnami/kubectl:1.18` no longer resolves.
2. That 1.18 image is built on Debian buster, whose apt repositories no longer serve a `Release` file, so `install_packages` fails even when the image is pulled from the `bitnamilegacy` archive namespace.

Reproduces on `main` (build 1046) and on the recent dependabot branches (1047, 1048).

## Solution

Base the image on `alpine/k8s`, which ships kubectl and `jq`, leaving only netcat to install. Its 1.21 tag matches the Kubernetes version `kind` v0.11.1 creates, where the previous pin was three minors behind the cluster.

The `chown` is also made absolute. `chown 1001 .kube` was relative and only worked because the old base happened to leave `WORKDIR` at `/`.

Happy to take this a different way if you would rather stay on a Debian base or pin a different kubectl version.